### PR TITLE
ci(repo): GitHub Actions CI + Changesets release pipeline (GHD-17)

### DIFF
--- a/.github/actions/setup/action.yml
+++ b/.github/actions/setup/action.yml
@@ -1,0 +1,19 @@
+name: Setup toolchain
+description: Checkout-independent pnpm + Node setup with dependency install (shared by CI and Release).
+
+runs:
+  using: composite
+  steps:
+    # pnpm version is read from package.json `packageManager` — single source of truth.
+    - name: Setup pnpm
+      uses: pnpm/action-setup@v4
+
+    - name: Setup Node
+      uses: actions/setup-node@v4
+      with:
+        node-version: 24
+        cache: pnpm
+
+    - name: Install dependencies
+      shell: bash
+      run: pnpm install --frozen-lockfile

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,43 @@
+name: CI
+
+on:
+  pull_request:
+    branches: [main]
+  push:
+    branches: [main]
+
+# Cancel in-progress runs for the same ref (e.g. new push to a PR branch).
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  verify:
+    name: lint · build · test
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.9.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Lint
+        run: pnpm lint
+
+      - name: Build
+        run: pnpm build
+
+      - name: Test
+        run: pnpm test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,15 +1,17 @@
 name: CI
 
 on:
+  # Run on every PR regardless of base branch (stacked/release branches included),
+  # so the lint/build/test gate is never skipped.
   pull_request:
-    branches: [main]
   push:
     branches: [main]
 
-# Cancel in-progress runs for the same ref (e.g. new push to a PR branch).
 concurrency:
   group: ci-${{ github.workflow }}-${{ github.ref }}
-  cancel-in-progress: true
+  # Only cancel superseded PR runs. Never cancel a push-to-main run, or a main
+  # commit could be left without a green required check.
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   verify:
@@ -19,19 +21,8 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.9.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
+      - name: Setup toolchain
+        uses: ./.github/actions/setup
 
       - name: Lint
         run: pnpm lint

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,58 @@
+name: Release
+
+on:
+  push:
+    branches: [main]
+
+# Only one release run at a time so the Version Packages PR stays consistent.
+concurrency:
+  group: release-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  release:
+    name: version (publish on hold)
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 11.9.0
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Build
+        run: pnpm build
+
+      # Opens/updates a "Version Packages" PR from accumulated changesets.
+      # `publish` is intentionally omitted: v1 is on publish-hold, so this only
+      # bumps versions + changelogs via the PR. Nothing is pushed to a registry.
+      #
+      # TO ENABLE NPM PUBLISH LATER:
+      #   1. Add an NPM_TOKEN repo secret (npm automation token).
+      #   2. Uncomment the `publish:` line below.
+      #   3. Add `NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}` to this step's env.
+      #   The action then publishes whenever the Version Packages PR is merged.
+      - name: Changesets — version PR
+        uses: changesets/action@v1
+        with:
+          version: pnpm run version-packages
+          # publish: pnpm run release
+          commit: "chore(release): version packages"
+          title: "chore(release): version packages"
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,12 +1,16 @@
 name: Release
 
+# Gate the release on CI: only run after the CI workflow completes successfully
+# on main. This keeps a red main commit from ever cutting a version (or, once
+# enabled, a publish). See the `if:` guard on the job below.
 on:
-  push:
+  workflow_run:
+    workflows: [CI]
+    types: [completed]
     branches: [main]
 
-# Only one release run at a time so the Version Packages PR stays consistent.
 concurrency:
-  group: release-${{ github.workflow }}-${{ github.ref }}
+  group: ${{ github.workflow }}
   cancel-in-progress: false
 
 permissions:
@@ -17,30 +21,22 @@ jobs:
   release:
     name: version (publish on hold)
     runs-on: ubuntu-latest
+    if: ${{ github.event.workflow_run.conclusion == 'success' }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup pnpm
-        uses: pnpm/action-setup@v4
-        with:
-          version: 11.9.0
-
-      - name: Setup Node
-        uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-
-      - name: Install dependencies
-        run: pnpm install --frozen-lockfile
-
-      - name: Build
-        run: pnpm build
+      - name: Setup toolchain
+        uses: ./.github/actions/setup
 
       # Opens/updates a "Version Packages" PR from accumulated changesets.
-      # `publish` is intentionally omitted: v1 is on publish-hold, so this only
-      # bumps versions + changelogs via the PR. Nothing is pushed to a registry.
+      # No build step: this path only bumps versions + changelogs (publish is on
+      # hold). The publish path below rebuilds via `pnpm run release`.
+      #
+      # KNOWN LIMITATION: the version PR is authored with the default GITHUB_TOKEN,
+      # and GitHub does not trigger workflows for token-authored events — so CI
+      # does NOT run on the "Version Packages" PR itself. To make that PR run CI
+      # (and to publish), supply a PAT/app token as `GITHUB_TOKEN` below.
       #
       # TO ENABLE NPM PUBLISH LATER:
       #   1. Add an NPM_TOKEN repo secret (npm automation token).

--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -7,8 +7,5 @@
     "github.vscode-github-actions",
     "editorconfig.editorconfig"
   ],
-  "unwantedRecommendations": [
-    "esbenp.prettier-vscode",
-    "dbaeumer.vscode-eslint"
-  ]
+  "unwantedRecommendations": ["esbenp.prettier-vscode", "dbaeumer.vscode-eslint"]
 }

--- a/biome.json
+++ b/biome.json
@@ -12,7 +12,8 @@
       "!**/.turbo",
       "!**/coverage",
       "!**/storybook-static",
-      "!**/node_modules"
+      "!**/node_modules",
+      "!**/.claude"
     ]
   },
   "formatter": {

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -2,7 +2,10 @@ packages:
   - 'apps/*'
   - 'packages/*'
 
-onlyBuiltDependencies:
-  - esbuild
+# pnpm v11: `allowBuilds` replaces the deprecated `onlyBuiltDependencies`.
+# Without it, esbuild's postinstall is ignored and a clean install (CI) fails
+# with ERR_PNPM_IGNORED_BUILDS.
+allowBuilds:
+  esbuild: true
 
 minimumReleaseAge: 180


### PR DESCRIPTION
## 무엇을 (GHD-17)

자율 개발/배포 파이프라인의 토대. `worktree → PR → code-review → CI green → 자동 머지` 흐름을 GitHub Actions로 깔았습니다.

### 변경
- **`.github/workflows/ci.yml`** — PR/main push에서 `lint → build → test`. pnpm 11.9.0 + Node 24, pnpm store 캐시, ref별 concurrency 취소.
- **`.github/workflows/release.yml`** — `changesets/action`으로 *Version Packages* PR 자동 생성. **publish는 보류** (퍼블리시 결정에 따라 `version`까지만; NPM_TOKEN 활성화 가이드는 주석으로 인라인).
- **`biome.json`** — 로컬 `.claude/` 설정을 lint 범위에서 제외.
- **`.vscode/extensions.json`** — biome 포맷 정렬.

### 검증 (로컬)
- `pnpm lint` ✅ (0 errors)
- `pnpm build` ✅ (@ghds/sketch-core)
- `pnpm test` ✅ (24 passed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)