### PR TITLE
ci(repo): Chromatic visual regression for 3 Storybooks (GHD-20)

### DIFF
--- a/.github/workflows/chromatic.yml
+++ b/.github/workflows/chromatic.yml
@@ -1,0 +1,72 @@
+name: Chromatic
+
+# Visual regression for the three Storybooks (GHD-20). Runs independently of CI
+# so each project posts its own "UI Tests" check directly on the PR; make those
+# checks required in branch protection to block on unreviewed visual changes.
+on:
+  pull_request:
+  push:
+    branches: [main]
+
+concurrency:
+  group: chromatic-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+permissions:
+  contents: read
+
+jobs:
+  chromatic:
+    name: chromatic (${{ matrix.name }})
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: react
+            workingDir: apps/storybook-react
+            package: storybook-react
+            buildScript: build-storybook
+            tokenSecret: CHROMATIC_PROJECT_TOKEN_REACT
+          - name: web-components
+            workingDir: apps/storybook-web-components
+            package: "@ghds/storybook-web-components"
+            buildScript: build-storybook
+            tokenSecret: CHROMATIC_PROJECT_TOKEN_WEB_COMPONENTS
+          - name: react-native
+            workingDir: apps/storybook-react-native
+            package: "@ghds/storybook-react-native"
+            buildScript: build
+            tokenSecret: CHROMATIC_PROJECT_TOKEN_REACT_NATIVE
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # Chromatic needs full git history to find the baseline commit.
+          fetch-depth: 0
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup
+
+      # Build the workspace libraries first so the Storybooks can resolve the
+      # internal @ghds/* packages (their gitignored dist is not committed, and
+      # the setup action only installs). `pnpm build` runs the full turbo graph.
+      - name: Build packages
+        run: pnpm build
+
+      # Build this leg's Storybook ourselves, then hand the static output to
+      # chromaui/action (rather than letting it install + build).
+      - name: Build Storybook
+        run: pnpm --filter ${{ matrix.package }} run ${{ matrix.buildScript }}
+
+      - name: Publish to Chromatic
+        uses: chromaui/action@v17
+        with:
+          projectToken: ${{ secrets[matrix.tokenSecret] }}
+          workingDir: ${{ matrix.workingDir }}
+          storybookBuildDir: storybook-static
+          # Let the workflow pass; the Chromatic "UI Tests" check is the blocking
+          # gate (make it required in branch protection).
+          exitZeroOnChanges: true
+          # On main, accept new snapshots as the baseline automatically.
+          autoAcceptChanges: main

--- a/apps/storybook-react-native/package.json
+++ b/apps/storybook-react-native/package.json
@@ -17,6 +17,7 @@
   "devDependencies": {
     "@ghds/tsconfig": "workspace:*",
     "@storybook/react-native-web-vite": "^9.0.0",
+    "chromatic": "^17.8.0",
     "react": "^19.1.0",
     "react-dom": "^19.1.0",
     "react-native-svg": "^15.0.0",

--- a/apps/storybook-react-native/src/Button.stories.tsx
+++ b/apps/storybook-react-native/src/Button.stories.tsx
@@ -40,7 +40,10 @@ export const DisabledDoesNotFire: Story = {
   play: async ({ args, canvasElement }) => {
     const canvas = within(canvasElement);
     const button = await canvas.findByRole('button', { name: 'No-op' });
-    await userEvent.click(button);
+    // A disabled react-native-web Pressable sets `pointer-events: none`, which
+    // userEvent refuses to click by default. Skip that guard so we can assert
+    // the actual behaviour: the press never reaches onPress.
+    await userEvent.click(button, { pointerEventsCheck: 0 });
     await expect(args.onPress).not.toHaveBeenCalled();
   },
 };

--- a/apps/storybook-react/package.json
+++ b/apps/storybook-react/package.json
@@ -17,6 +17,7 @@
     "@storybook/addon-docs": "^9.1.0",
     "@storybook/react-vite": "^9.1.0",
     "@vitejs/plugin-react": "^4.3.0",
+    "chromatic": "^17.8.0",
     "react": "^19.0.0",
     "react-dom": "^19.0.0",
     "storybook": "^9.1.0",

--- a/apps/storybook-web-components/package.json
+++ b/apps/storybook-web-components/package.json
@@ -26,6 +26,7 @@
     "@storybook/test-runner": "^0.21.0",
     "@storybook/web-components": "^8.4.7",
     "@storybook/web-components-vite": "^8.4.7",
+    "chromatic": "^17.8.0",
     "storybook": "^8.4.7",
     "typescript": "^6.0.0",
     "vite": "^5.4.11"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -48,6 +48,9 @@ importers:
       '@vitejs/plugin-react':
         specifier: ^4.3.0
         version: 4.7.0(vite@6.4.3(@types/node@24.13.2)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))
+      chromatic:
+        specifier: ^17.8.0
+        version: 17.8.0
       react:
         specifier: ^19.0.0
         version: 19.2.7
@@ -79,6 +82,9 @@ importers:
       '@storybook/react-native-web-vite':
         specifier: ^9.0.0
         version: 9.1.20(react-dom@19.2.7(react@19.2.7))(react-native-web@0.20.0(react-dom@19.2.7(react@19.2.7))(react@19.2.7))(react-native@0.79.7(@babel/core@7.29.7)(@types/react@19.2.17)(react@19.2.7))(react@19.2.7)(storybook@9.1.20(@testing-library/dom@10.4.1)(prettier@3.9.1)(vite@7.3.6(@types/node@24.13.2)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0)))(typescript@6.0.3)(vite@7.3.6(@types/node@24.13.2)(jiti@2.6.1)(terser@5.48.0)(yaml@2.9.0))
+      chromatic:
+        specifier: ^17.8.0
+        version: 17.8.0
       react:
         specifier: ^19.1.0
         version: 19.2.7
@@ -137,6 +143,9 @@ importers:
       '@storybook/web-components-vite':
         specifier: ^8.4.7
         version: 8.6.18(lit@3.3.3)(storybook@8.6.18(prettier@3.9.1))(vite@5.4.21(@types/node@24.13.2)(terser@5.48.0))
+      chromatic:
+        specifier: ^17.8.0
+        version: 17.8.0
       storybook:
         specifier: ^8.4.7
         version: 8.6.18(prettier@3.9.1)
@@ -3169,6 +3178,22 @@ packages:
   chokidar@5.0.0:
     resolution: {integrity: sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==}
     engines: {node: '>= 20.19.0'}
+
+  chromatic@17.8.0:
+    resolution: {integrity: sha512-xcn2TGdbrKHQbGAo3wZc5qoKaPe+CEvhAEcky9OCpofGd3DJucLFEYpk8wYgHKgR5XAI9X8Op1C6fWlvdjxE/g==}
+    engines: {node: '>=22.0.0'}
+    hasBin: true
+    peerDependencies:
+      '@chromatic-com/cypress': ^0.*.* || ^1.0.0
+      '@chromatic-com/playwright': ^0.*.* || ^1.0.0
+      '@chromatic-com/vitest': ^0.*.* || ^1.0.0
+    peerDependenciesMeta:
+      '@chromatic-com/cypress':
+        optional: true
+      '@chromatic-com/playwright':
+        optional: true
+      '@chromatic-com/vitest':
+        optional: true
 
   chrome-launcher@0.15.2:
     resolution: {integrity: sha512-zdLEwNo3aUVzIhKhTtXfxhdvZhUghrnmkvcAq2NoDd+LeOHKf03H5jwZ8T/STsAlzyALkBVK552iaG1fGf1xVQ==}
@@ -9810,6 +9835,10 @@ snapshots:
   chokidar@5.0.0:
     dependencies:
       readdirp: 5.0.0
+
+  chromatic@17.8.0:
+    dependencies:
+      semver: 7.8.5
 
   chrome-launcher@0.15.2:
     dependencies:


### PR DESCRIPTION
## Summary
Storybook 3종(react·web-components·react-native)을 Chromatic에 연결해 PR마다 시각적 회귀 검사를 수행합니다. (GHD-20, 마일스톤 6 배포·인프라)

- `.github/workflows/chromatic.yml` 신규 — `pull_request` + `push(main)` 트리거, 3-way 매트릭스. 빌드 스크립트 차이(react-native만 `build`, 나머지 `build-storybook`)를 매트릭스로 흡수.
- 각 잡: `pnpm build`(워크스페이스 lib dist 생성) → 해당 Storybook 빌드 → `chromaui/action@v17`이 `storybook-static` 업로드.
- `exitZeroOnChanges: true`로 잡은 green 유지, 블로킹은 Chromatic **"UI Tests"** 체크가 담당. `autoAcceptChanges: main`으로 베이스라인 자동 갱신.
- 3개 Storybook 앱에 `chromatic` devDep 추가(로컬 `npx chromatic`용).

## 검증
- 클린 상태(dist 제거)에서 `pnpm build → build-storybook` 시퀀스 3종 모두 `storybook-static/index.html` 생성 확인.
- biome 린트 통과. Secrets(`CHROMATIC_PROJECT_TOKEN_REACT`/`_WEB_COMPONENTS`/`_REACT_NATIVE`) 등록 완료 상태.
- 적대적 code-review 1회(블로커 1건 수정: CI에서 lib dist 미빌드 → `pnpm build` 선행 추가).

## 사람이 1회 할 일
- 첫 실행 후 Chromatic 대시보드에서 **베이스라인 Accept** + **"UI Tests" 체크를 PR 필수(블로킹)** 로 설정.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added automated visual regression checks for Storybook across React, Web Components, and React Native.
  * Visual snapshots now run on pull requests and pushes to the main branch.
  * Snapshot updates can be accepted automatically on main.

* **Chores**
  * Added the required test tooling to the Storybook apps to support the new visual checks.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->