### PR TITLE
feat(repo): deploy Astro docs site to GitHub Pages (GHD-19)

### DIFF
--- a/.github/workflows/deploy-website.yml
+++ b/.github/workflows/deploy-website.yml
@@ -1,0 +1,51 @@
+name: Deploy website
+
+# Builds the Astro docs site (apps/website) and publishes it to GitHub Pages
+# (GHD-19). Requires repo Settings → Pages → Source = "GitHub Actions".
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+# Allow one concurrent deployment; don't cancel an in-progress publish.
+concurrency:
+  group: pages
+  cancel-in-progress: false
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup toolchain
+        uses: ./.github/actions/setup
+
+      # `pnpm build` runs the whole turbo graph, so @ghds/tokens and the
+      # component packages build before apps/website consumes them.
+      - name: Build
+        run: pnpm build
+
+      - name: Upload Pages artifact
+        uses: actions/upload-pages-artifact@v3
+        with:
+          path: apps/website/dist
+
+  deploy:
+    name: deploy
+    needs: build
+    runs-on: ubuntu-latest
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v5

--- a/apps/website/astro.config.mjs
+++ b/apps/website/astro.config.mjs
@@ -13,5 +13,10 @@ import { defineConfig } from 'astro/config';
 //   register `<gh-button>` / `<gh-card>` / `<gh-input>`. No SSR integration is
 //   required for them.
 export default defineConfig({
+  // Deployed to GitHub Pages as a project site, so the app lives under the
+  // repository-name subpath. `base` makes Astro prefix processed assets and
+  // injected tags; authored links are made base-aware via `src/lib/withBase`.
+  site: 'https://gyeonghokim.github.io',
+  base: '/gyeongho-design-system',
   integrations: [react(), mdx()],
 });

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -2,6 +2,7 @@
 import '@ghds/tokens/css';
 import '../styles/global.css';
 import { NAV } from '../lib/nav';
+import { withBase } from '../lib/withBase';
 
 interface Props {
   /** Document <title>; the site name is appended. */
@@ -17,10 +18,12 @@ const here = normalize(Astro.url.pathname);
 
 // A link is current on its own page and any nested route beneath it. The home
 // link ('/') matches only the home page, so 시작하기 is no longer wrongly active.
+// `here` includes the configured base path, so compare against base-aware hrefs.
+const home = normalize(withBase('/'));
 function isCurrent(href: string): boolean {
-  const target = normalize(href);
-  if (target === '/') {
-    return here === '/';
+  const target = normalize(withBase(href));
+  if (target === home) {
+    return here === home;
   }
   return here === target || here.startsWith(`${target}/`);
 }
@@ -50,14 +53,14 @@ function isCurrent(href: string): boolean {
   </head>
   <body>
     <header class="site-header">
-      <a class="brand" href="/">
+      <a class="brand" href={withBase('/')}>
         GHDS <small>GH Design System</small>
       </a>
       <nav class="site-nav" aria-label="주요 메뉴">
-        <a href="/" aria-current={isCurrent('/') ? 'page' : undefined}>홈</a>
+        <a href={withBase('/')} aria-current={isCurrent('/') ? 'page' : undefined}>홈</a>
         {
           NAV.map((item) => (
-            <a href={item.href} aria-current={isCurrent(item.href) ? 'page' : undefined}>
+            <a href={withBase(item.href)} aria-current={isCurrent(item.href) ? 'page' : undefined}>
               {item.label}
             </a>
           ))

--- a/apps/website/src/lib/withBase.ts
+++ b/apps/website/src/lib/withBase.ts
@@ -1,0 +1,12 @@
+/**
+ * Prefix an absolute app path with the configured base path so internal links
+ * work under the GitHub Pages project subpath.
+ *
+ * Astro exposes the `base` config as `import.meta.env.BASE_URL`, always with a
+ * trailing slash (e.g. `/gyeongho-design-system/`). Authored `href`/links are
+ * NOT rewritten automatically, so build them through this helper.
+ *
+ * @param path Absolute app path beginning with `/` (e.g. `/components/`).
+ */
+export const withBase = (path: string): string =>
+  `${import.meta.env.BASE_URL.replace(/\/$/, '')}${path}`;

--- a/apps/website/src/pages/getting-started.mdx
+++ b/apps/website/src/pages/getting-started.mdx
@@ -47,5 +47,5 @@ import '@ghds/web-components';
 
 ## 다음 단계
 
-- [디자인 스타일](/design-style/) — 토큰으로 자동 생성된 색상·타이포·간격 갤러리
-- [컴포넌트 가이드](/components/) — React와 Lit을 나란히 비교하는 라이브 데모
+- [디자인 스타일](../design-style/) — 토큰으로 자동 생성된 색상·타이포·간격 갤러리
+- [컴포넌트 가이드](../components/) — React와 Lit을 나란히 비교하는 라이브 데모

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -1,6 +1,7 @@
 ---
 import BaseLayout from '../layouts/BaseLayout.astro';
 import { NAV } from '../lib/nav';
+import { withBase } from '../lib/withBase';
 ---
 
 <BaseLayout
@@ -16,8 +17,8 @@ import { NAV } from '../lib/nav';
       아래 문서에서 토큰, 컴포넌트, 패턴을 둘러보세요.
     </p>
     <p class="demo-row">
-      <a class="theme-toggle" href="/getting-started/">시작하기 →</a>
-      <a class="theme-toggle" href="/components/">컴포넌트 보기</a>
+      <a class="theme-toggle" href={withBase('/getting-started/')}>시작하기 →</a>
+      <a class="theme-toggle" href={withBase('/components/')}>컴포넌트 보기</a>
     </p>
   </section>
 
@@ -26,7 +27,7 @@ import { NAV } from '../lib/nav';
     <div class="card-grid">
       {
         NAV.map((item) => (
-          <a class="io-card" href={item.href}>
+          <a class="io-card" href={withBase(item.href)}>
             <h3>{item.label}</h3>
             <span class="io-en">{item.labelEn}</span>
             <p>{item.summary}</p>


### PR DESCRIPTION
## Summary
Astro 문서 사이트(`apps/website`)를 GitHub Pages 프로젝트 사이트(`https://gyeonghokim.github.io/gyeongho-design-system/`)로 배포합니다. (GHD-19, 마일스톤 6 배포·인프라)

- `astro.config.mjs`: `site` + `base: '/gyeongho-design-system'` 설정 → Astro가 처리 자산/주입 태그를 서브패스로 prefix.
- `src/lib/withBase.ts` 헬퍼 신규 + 저자 작성 내부 링크 전부 base-aware화(BaseLayout nav·브랜드, index 히어로·카드 그리드). Astro는 저자 `href`를 자동 변환하지 않으므로 필요.
- `isCurrent()`를 base 포함 경로 기준으로 비교하도록 조정.
- `getting-started.mdx`는 base-독립 상대링크 사용.
- `.github/workflows/deploy-website.yml` 신규 — 공유 setup으로 워크스페이스 순서 빌드 → `upload-pages-artifact`(apps/website/dist) → `deploy-pages`. Actions 기반 Pages는 Jekyll을 건너뛰어 `_astro/` 언더스코어 디렉터리에 `.nojekyll` 불필요.

## 검증
- `pnpm build` 후 `dist/index.html`·하위 페이지 링크/자산이 모두 `/gyeongho-design-system/...`로 prefix됨 확인.
- MDX 상대링크가 `/gyeongho-design-system/design-style|components/`로 정확히 해석.
- `apps/website` vitest 5/5 통과, biome 린트 통과.
- 적대적 code-review 1회 — 블로커·major 없음.

## 사람이 1회 할 일
- 레포 **Settings → Pages → Source = "GitHub Actions"** 설정해야 실제 게시됨(설정 전엔 deploy 잡 실패).

🤖 Generated with [Claude Code](https://claude.com/claude-code)