### PR TITLE
fix(react): isolate sketch layer so components render inside opaque containers (GHD-44)

### DIFF
--- a/packages/react/src/components/Button.stories.tsx
+++ b/packages/react/src/components/Button.stories.tsx
@@ -24,6 +24,21 @@ export const Neutral: Story = { args: { variant: 'neutral', children: 'Cancel' }
 
 export const Disabled: Story = { args: { disabled: true, children: 'Disabled' } };
 
+/**
+ * Visual-regression guard for GHD-44: the button is placed inside an
+ * opaque-background container. If its root ever loses its stacking context, the
+ * `z-index: -1` sketch surface (and the light label) paint behind this white
+ * box and vanish — a change Chromatic will flag.
+ */
+export const OnOpaqueSurface: Story = {
+  args: { variant: 'primary', children: 'Primary' },
+  render: (args) => (
+    <div style={{ background: '#ffffff', padding: 24 }}>
+      <Button {...args} />
+    </div>
+  ),
+};
+
 export const AsLink: Story = {
   render: (args) => (
     <Button {...args} asChild>

--- a/packages/react/src/components/Button.stories.tsx
+++ b/packages/react/src/components/Button.stories.tsx
@@ -26,14 +26,27 @@ export const Disabled: Story = { args: { disabled: true, children: 'Disabled' } 
 
 /**
  * Visual-regression guard for GHD-44: the button is placed inside an
- * opaque-background container. If its root ever loses its stacking context, the
- * `z-index: -1` sketch surface (and the light label) paint behind this white
- * box and vanish — a change Chromatic will flag.
+ * opaque-background container (colors/spacing from `@ghds/tokens` CSS vars). If
+ * its root ever loses its stacking context, the `z-index: -1` sketch surface
+ * (and the light label) paint behind this box and vanish — a change Chromatic
+ * will flag. The dark variant is where a light label most visibly disappears.
  */
 export const OnOpaqueSurface: Story = {
   args: { variant: 'primary', children: 'Primary' },
   render: (args) => (
-    <div style={{ background: '#ffffff', padding: 24 }}>
+    <div style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}>
+      <Button {...args} />
+    </div>
+  ),
+};
+
+export const OnOpaqueSurfaceDark: Story = {
+  args: { variant: 'primary', children: 'Primary' },
+  render: (args) => (
+    <div
+      data-theme="dark"
+      style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}
+    >
       <Button {...args} />
     </div>
   ),

--- a/packages/react/src/components/Button.test.tsx
+++ b/packages/react/src/components/Button.test.tsx
@@ -18,6 +18,15 @@ describe('Button', () => {
     expect(container.querySelectorAll('svg path').length).toBeGreaterThan(0);
   });
 
+  it('isolates the sketch layer in its own stacking context', () => {
+    // Regression (GHD-44): the sketch surface paints at `z-index: -1`. If the
+    // host does not establish a stacking context, an opaque-background ancestor
+    // paints over it and the button (with its light label) disappears.
+    const { container } = render(<Button>Draw</Button>);
+    const host = container.querySelector('svg')?.parentElement;
+    expect(host).toHaveStyle({ isolation: 'isolate' });
+  });
+
   it('fires onClick when activated', async () => {
     const user = userEvent.setup();
     const onClick = vi.fn();

--- a/packages/react/src/components/Button.test.tsx
+++ b/packages/react/src/components/Button.test.tsx
@@ -23,8 +23,9 @@ describe('Button', () => {
     // host does not establish a stacking context, an opaque-background ancestor
     // paints over it and the button (with its light label) disappears.
     const { container } = render(<Button>Draw</Button>);
-    const host = container.querySelector('svg')?.parentElement;
-    expect(host).toHaveStyle({ isolation: 'isolate' });
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.parentElement).toHaveStyle({ isolation: 'isolate' });
   });
 
   it('fires onClick when activated', async () => {

--- a/packages/react/src/components/Button.tsx
+++ b/packages/react/src/components/Button.tsx
@@ -134,6 +134,12 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
 
   const rootStyle: CSSProperties = {
     position: 'relative',
+    // Establish a stacking context so the decorative `SketchSurface` (painted at
+    // `z-index: -1`) stays scoped to this button. Without it, the negative layer
+    // is hoisted to an ancestor's stacking context and hidden behind any
+    // opaque-background container (card, panel, section) — the sketch and, for
+    // filled variants, the light label become invisible.
+    isolation: 'isolate',
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/react/src/components/Button.tsx
+++ b/packages/react/src/components/Button.tsx
@@ -6,7 +6,7 @@ import { useSketch } from '../hooks/useSketch.js';
 import { cssVars } from '../lib/cssVars.js';
 import { mergeRefs } from '../lib/mergeRefs.js';
 import { toPx } from '../lib/units.js';
-import { SketchSurface } from './SketchSurface.js';
+import { SketchSurface, sketchHostStyle } from './SketchSurface.js';
 
 /** Visual intent of the button. */
 export type ButtonVariant = 'primary' | 'danger' | 'neutral';
@@ -133,13 +133,9 @@ export const Button = forwardRef<HTMLButtonElement, ButtonProps>(function Button
   const colors = resolveColors(variant, state, disabled);
 
   const rootStyle: CSSProperties = {
-    position: 'relative',
-    // Establish a stacking context so the decorative `SketchSurface` (painted at
-    // `z-index: -1`) stays scoped to this button. Without it, the negative layer
-    // is hoisted to an ancestor's stacking context and hidden behind any
-    // opaque-background container (card, panel, section) — the sketch and, for
-    // filled variants, the light label become invisible.
-    isolation: 'isolate',
+    // `position: relative` + `isolation: isolate` — scopes the `SketchSurface`
+    // (`z-index: -1`) to this button so an opaque ancestor can't paint over it.
+    ...sketchHostStyle,
     display: 'inline-flex',
     alignItems: 'center',
     justifyContent: 'center',

--- a/packages/react/src/components/Card.stories.tsx
+++ b/packages/react/src/components/Card.stories.tsx
@@ -40,6 +40,23 @@ export const Hachure: Story = {
   },
 };
 
+/**
+ * Visual-regression guard for GHD-44: the card sits inside an opaque-background
+ * container. If its root loses its stacking context, the `z-index: -1` sketch
+ * outline paints behind this white box and disappears — flagged by Chromatic.
+ */
+export const OnOpaqueSurface: Story = {
+  args: {
+    style: { maxWidth: 320 },
+    children: <span>Sketch outline stays visible on an opaque surface.</span>,
+  },
+  render: (args) => (
+    <div style={{ background: '#ffffff', padding: 24 }}>
+      <Card {...args} />
+    </div>
+  ),
+};
+
 export const AsRegion: Story = {
   args: {
     role: 'region',

--- a/packages/react/src/components/Card.stories.tsx
+++ b/packages/react/src/components/Card.stories.tsx
@@ -42,8 +42,9 @@ export const Hachure: Story = {
 
 /**
  * Visual-regression guard for GHD-44: the card sits inside an opaque-background
- * container. If its root loses its stacking context, the `z-index: -1` sketch
- * outline paints behind this white box and disappears — flagged by Chromatic.
+ * container (colors/spacing from `@ghds/tokens` CSS vars). If its root loses its
+ * stacking context, the `z-index: -1` sketch outline paints behind this box and
+ * disappears — flagged by Chromatic in both light and dark schemes.
  */
 export const OnOpaqueSurface: Story = {
   args: {
@@ -51,7 +52,22 @@ export const OnOpaqueSurface: Story = {
     children: <span>Sketch outline stays visible on an opaque surface.</span>,
   },
   render: (args) => (
-    <div style={{ background: '#ffffff', padding: 24 }}>
+    <div style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}>
+      <Card {...args} />
+    </div>
+  ),
+};
+
+export const OnOpaqueSurfaceDark: Story = {
+  args: {
+    style: { maxWidth: 320 },
+    children: <span>Sketch outline stays visible on a dark opaque surface.</span>,
+  },
+  render: (args) => (
+    <div
+      data-theme="dark"
+      style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}
+    >
       <Card {...args} />
     </div>
   ),

--- a/packages/react/src/components/Card.test.tsx
+++ b/packages/react/src/components/Card.test.tsx
@@ -22,6 +22,14 @@ describe('Card', () => {
     expect(container.querySelectorAll('svg path').length).toBeGreaterThan(0);
   });
 
+  it('isolates the sketch layer in its own stacking context', () => {
+    // Regression (GHD-44): the sketch surface paints at `z-index: -1` and must
+    // stay scoped to the card, or an opaque-background ancestor paints over it.
+    const { container } = render(<Card>content</Card>);
+    const host = container.querySelector('svg')?.parentElement;
+    expect(host).toHaveStyle({ isolation: 'isolate' });
+  });
+
   it('forwards arbitrary props such as role to the root element', () => {
     render(
       <Card role="region" aria-label="Stats">

--- a/packages/react/src/components/Card.test.tsx
+++ b/packages/react/src/components/Card.test.tsx
@@ -26,8 +26,9 @@ describe('Card', () => {
     // Regression (GHD-44): the sketch surface paints at `z-index: -1` and must
     // stay scoped to the card, or an opaque-background ancestor paints over it.
     const { container } = render(<Card>content</Card>);
-    const host = container.querySelector('svg')?.parentElement;
-    expect(host).toHaveStyle({ isolation: 'isolate' });
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.parentElement).toHaveStyle({ isolation: 'isolate' });
   });
 
   it('forwards arbitrary props such as role to the root element', () => {

--- a/packages/react/src/components/Card.tsx
+++ b/packages/react/src/components/Card.tsx
@@ -4,7 +4,7 @@ import { useSketch } from '../hooks/useSketch.js';
 import { cssVars } from '../lib/cssVars.js';
 import { mergeRefs } from '../lib/mergeRefs.js';
 import { toPx } from '../lib/units.js';
-import { SketchSurface } from './SketchSurface.js';
+import { SketchSurface, sketchHostStyle } from './SketchSurface.js';
 
 export interface CardProps extends HTMLAttributes<HTMLDivElement> {
   /**
@@ -45,10 +45,9 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
   const ref = mergeRefs(sketchRef, forwardedRef);
 
   const rootStyle: CSSProperties = {
-    position: 'relative',
-    // Scope the decorative `SketchSurface` (`z-index: -1`) to this card so an
-    // opaque-background ancestor can't paint over it. See Button for details.
-    isolation: 'isolate',
+    // Scopes the `SketchSurface` (`z-index: -1`) to this card so an opaque
+    // ancestor can't paint over it (see `sketchHostStyle`).
+    ...sketchHostStyle,
     display: 'flex',
     flexDirection: 'column',
     gap: card.gap,

--- a/packages/react/src/components/Card.tsx
+++ b/packages/react/src/components/Card.tsx
@@ -46,6 +46,9 @@ export const Card = forwardRef<HTMLDivElement, CardProps>(function Card(
 
   const rootStyle: CSSProperties = {
     position: 'relative',
+    // Scope the decorative `SketchSurface` (`z-index: -1`) to this card so an
+    // opaque-background ancestor can't paint over it. See Button for details.
+    isolation: 'isolate',
     display: 'flex',
     flexDirection: 'column',
     gap: card.gap,

--- a/packages/react/src/components/Input.stories.tsx
+++ b/packages/react/src/components/Input.stories.tsx
@@ -22,6 +22,20 @@ export const Disabled: Story = {
   args: { disabled: true, value: 'locked@example.com' },
 };
 
+/**
+ * Visual-regression guard for GHD-44: the field sits inside an opaque-background
+ * container. If its control loses its stacking context, the `z-index: -1` sketch
+ * box paints behind this white box and disappears — flagged by Chromatic.
+ */
+export const OnOpaqueSurface: Story = {
+  args: { label: 'On an opaque surface' },
+  render: (args) => (
+    <div style={{ background: '#ffffff', padding: 24 }}>
+      <Input {...args} />
+    </div>
+  ),
+};
+
 export const TypingInteraction: Story = {
   args: { label: 'Name' },
   play: async ({ canvasElement }) => {

--- a/packages/react/src/components/Input.stories.tsx
+++ b/packages/react/src/components/Input.stories.tsx
@@ -24,13 +24,26 @@ export const Disabled: Story = {
 
 /**
  * Visual-regression guard for GHD-44: the field sits inside an opaque-background
- * container. If its control loses its stacking context, the `z-index: -1` sketch
- * box paints behind this white box and disappears — flagged by Chromatic.
+ * container (colors/spacing from `@ghds/tokens` CSS vars). If its control loses
+ * its stacking context, the `z-index: -1` sketch box paints behind this box and
+ * disappears — flagged by Chromatic in both light and dark schemes.
  */
 export const OnOpaqueSurface: Story = {
   args: { label: 'On an opaque surface' },
   render: (args) => (
-    <div style={{ background: '#ffffff', padding: 24 }}>
+    <div style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}>
+      <Input {...args} />
+    </div>
+  ),
+};
+
+export const OnOpaqueSurfaceDark: Story = {
+  args: { label: 'On a dark opaque surface' },
+  render: (args) => (
+    <div
+      data-theme="dark"
+      style={{ background: 'var(--sys-color-bg-surface)', padding: 'var(--sys-spacing-lg)' }}
+    >
       <Input {...args} />
     </div>
   ),

--- a/packages/react/src/components/Input.test.tsx
+++ b/packages/react/src/components/Input.test.tsx
@@ -22,6 +22,14 @@ describe('Input', () => {
     expect(container.querySelectorAll('svg path').length).toBeGreaterThan(0);
   });
 
+  it('isolates the sketch layer in its own stacking context', () => {
+    // Regression (GHD-44): the sketch surface paints at `z-index: -1` and must
+    // stay scoped to the control, or an opaque-background ancestor paints over it.
+    const { container } = render(<Input label="City" />);
+    const host = container.querySelector('svg')?.parentElement;
+    expect(host).toHaveStyle({ isolation: 'isolate' });
+  });
+
   it('marks the field invalid and announces the error', () => {
     render(<Input label="Email" error="Required" />);
     const field = screen.getByLabelText('Email');

--- a/packages/react/src/components/Input.test.tsx
+++ b/packages/react/src/components/Input.test.tsx
@@ -26,8 +26,9 @@ describe('Input', () => {
     // Regression (GHD-44): the sketch surface paints at `z-index: -1` and must
     // stay scoped to the control, or an opaque-background ancestor paints over it.
     const { container } = render(<Input label="City" />);
-    const host = container.querySelector('svg')?.parentElement;
-    expect(host).toHaveStyle({ isolation: 'isolate' });
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg?.parentElement).toHaveStyle({ isolation: 'isolate' });
   });
 
   it('marks the field invalid and announces the error', () => {

--- a/packages/react/src/components/Input.tsx
+++ b/packages/react/src/components/Input.tsx
@@ -79,6 +79,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
 
   const controlStyle: CSSProperties = {
     position: 'relative',
+    // Scope the decorative `SketchSurface` (`z-index: -1`) to this control so an
+    // opaque-background ancestor can't paint over it. See Button for details.
+    isolation: 'isolate',
     display: 'flex',
     boxSizing: 'border-box',
   };

--- a/packages/react/src/components/Input.tsx
+++ b/packages/react/src/components/Input.tsx
@@ -11,7 +11,7 @@ import {
 import { useSketch } from '../hooks/useSketch.js';
 import { cssVars } from '../lib/cssVars.js';
 import { toPx } from '../lib/units.js';
-import { SketchSurface } from './SketchSurface.js';
+import { SketchSurface, sketchHostStyle } from './SketchSurface.js';
 
 export interface InputProps extends Omit<InputHTMLAttributes<HTMLInputElement>, 'size'> {
   /** Visible label. Associated to the input via Radix `Label` for accessibility. */
@@ -78,10 +78,9 @@ export const Input = forwardRef<HTMLInputElement, InputProps>(function Input(
   };
 
   const controlStyle: CSSProperties = {
-    position: 'relative',
-    // Scope the decorative `SketchSurface` (`z-index: -1`) to this control so an
-    // opaque-background ancestor can't paint over it. See Button for details.
-    isolation: 'isolate',
+    // Scopes the `SketchSurface` (`z-index: -1`) to this control so an opaque
+    // ancestor can't paint over it (see `sketchHostStyle`).
+    ...sketchHostStyle,
     display: 'flex',
     boxSizing: 'border-box',
   };

--- a/packages/react/src/components/SketchSurface.tsx
+++ b/packages/react/src/components/SketchSurface.tsx
@@ -29,6 +29,23 @@ export interface SketchSurfaceProps {
   style?: CSSProperties;
 }
 
+/**
+ * The style every host of a {@link SketchSurface} must apply to its root
+ * element. The surface paints at `z-index: -1` (see {@link BASE_STYLE}), so the
+ * host has to establish its own stacking context — otherwise that negative
+ * layer is hoisted to an ancestor's stacking context and painted behind any
+ * opaque-background container (card, panel, section), hiding the sketch and,
+ * for filled components, the light label (GHD-44). `position: relative` also
+ * makes the absolutely-positioned surface size to the host's border box.
+ *
+ * Exported so the requirement lives next to the `z-index: -1` it compensates
+ * for, rather than being re-derived by each consumer.
+ */
+export const sketchHostStyle: CSSProperties = {
+  position: 'relative',
+  isolation: 'isolate',
+};
+
 const BASE_STYLE: CSSProperties = {
   position: 'absolute',
   inset: 0,


### PR DESCRIPTION
## Problem (GHD-44)

Every `@ghds/react` component rendered its text but **no sketch outline/fill**, and the **primary Button vanished entirely** when placed inside a container with an opaque background (a card, demo panel, page section).

**Root cause (reproduced in a headless browser):** `SketchSurface` paints at `z-index: -1`, but the component roots used `position: relative` with `z-index: auto`, so they did **not** establish a stacking context. The negative layer was hoisted into an ancestor's stacking context and painted **behind** the intermediate opaque-background block. For filled variants the light label (`#ffffff`) then sat on a transparent box → the whole button disappeared.

| Before (bug) | After (`isolation: isolate`) |
|---|---|
| primary button invisible inside a white card | button renders normally |

## Fix

- Add a stacking context to each `SketchSurface` host so the `z-index: -1` layer stays scoped to the component.
- The requirement is owned by **`sketchHostStyle`** (`position: relative` + `isolation: isolate`), exported from `SketchSurface` and spread into `Button` / `Card` / `Input` — so it lives next to the `z-index: -1` it compensates for and a future consumer can't forget it.

## Tests

- Unit regression tests: each component's sketch host establishes `isolation: isolate`.
- **Visual-regression stories** (`OnOpaqueSurface`) render each component inside an opaque container — the scenario jsdom can't observe — so **Chromatic** flags any future stacking-context loss.
- `pnpm test` 20/20 · biome lint clean · `tsc` build clean.

## Known tradeoff

`isolation: isolate` means a positively-z-indexed descendant overlay is confined to the component's stacking context. This is acceptable: overlays that must escape a container are portaled to `body`, and the alternative is the current total breakage for every consumer.

Fixes GHD-44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved decorative sketch rendering in Button, Card, and Input so the sketch layer remains visible when placed on opaque backgrounds.
* **New Features**
  * Added Storybook stories for Button, Card, and Input showing the components on opaque surfaces, including a dark-theme variant, for clearer visual regression review.
* **Tests**
  * Added regression tests to verify the sketch layer is protected by a dedicated stacking/isolated rendering context across these components.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->