### PR TITLE
chore(react): add changeset for GHD-44 sketch isolation fix

### DIFF
--- a/.changeset/ghd-44-react-sketch-isolation.md
+++ b/.changeset/ghd-44-react-sketch-isolation.md
@@ -1,0 +1,5 @@
+---
+"@ghds/react": patch
+---
+
+Fix sketch surface hidden behind opaque-background ancestors (GHD-44). Button, Card, and Input now establish their own stacking context (`isolation: isolate`) so the decorative `z-index: -1` sketch layer — and, for filled variants, the light label — no longer disappear when the component is placed inside a card, panel, or section with an opaque background.


### PR DESCRIPTION
The GHD-44 fix (#25) merged **without a changeset**, so `@ghds/react` would not be versioned or published by the release pipeline. This adds the missing `patch` changeset so the fix ships.

- `@ghds/react`: patch — sketch surface no longer hidden behind opaque-background ancestors.
- Internal dependents (`storybook-react`, `@ghds/website`) patch-bump automatically per `updateInternalDependencies: patch`.

Follow-up to #25 · GHD-44.

🤖 Generated with [Claude Code](https://claude.com/claude-code)