### PR TITLE
fix(sketch): deterministic seed override for stable visual snapshots (GHD-45)

### DIFF
--- a/.changeset/ghd-45-deterministic-sketch-seed.md
+++ b/.changeset/ghd-45-deterministic-sketch-seed.md
@@ -1,0 +1,8 @@
+---
+"@ghds/sketch-core": minor
+"@ghds/react": patch
+"@ghds/web-components": patch
+"@ghds/react-native": patch
+---
+
+Add a deterministic sketch-seed override so visual-regression snapshots are stable (GHD-45). `@ghds/sketch-core` now exports `forcedSeed()` / `setForcedSeed()`: when a host pins a seed, every adapter (`useSketch` in React/React Native, `SketchyBase` in web components) uses it instead of a random per-instance seed, making the hand-drawn geometry byte-identical across runs. Production and local dev are unchanged — the seed stays random unless explicitly pinned (e.g. by Storybook under Chromatic).

--- a/apps/storybook-react-native/.storybook/preview.tsx
+++ b/apps/storybook-react-native/.storybook/preview.tsx
@@ -1,12 +1,15 @@
 import { darkTheme, lightTheme, ThemeProvider } from '@ghds/react-native';
 import type { Decorator, Preview } from '@storybook/react';
+import isChromatic from 'chromatic/isChromatic';
 import { View } from 'react-native';
 
 // GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
 // byte-deterministic across snapshot runs — otherwise every run re-rolls the
-// random seed and reports a false visual diff. Key mirrors
-// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
-if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+// random seed and reports a false visual diff. `isChromatic()` checks both the
+// user agent and the `chromatic=true` URL param — the URL param is the reliable
+// signal for React Native (web) Storybook, where the UA may not carry
+// "Chromatic". Key mirrors `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core.
+if (isChromatic()) {
   (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
 }
 

--- a/apps/storybook-react-native/.storybook/preview.tsx
+++ b/apps/storybook-react-native/.storybook/preview.tsx
@@ -2,6 +2,14 @@ import { darkTheme, lightTheme, ThemeProvider } from '@ghds/react-native';
 import type { Decorator, Preview } from '@storybook/react';
 import { View } from 'react-native';
 
+// GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
+// byte-deterministic across snapshot runs — otherwise every run re-rolls the
+// random seed and reports a false visual diff. Key mirrors
+// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
+if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+  (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
+}
+
 /**
  * Global theme switcher. `@ghds/react-native` ships both light and dark Restyle
  * themes (built from `@ghds/tokens`); the app picks one — here a Storybook

--- a/apps/storybook-react/.storybook/preview.tsx
+++ b/apps/storybook-react/.storybook/preview.tsx
@@ -1,6 +1,14 @@
 import '@ghds/tokens/css';
 import type { Decorator, Preview } from '@storybook/react-vite';
 
+// GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
+// byte-deterministic across snapshot runs — otherwise every run re-rolls the
+// random seed and reports a false visual diff. Key mirrors
+// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
+if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+  (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
+}
+
 /**
  * Wraps every story in a themed surface. The `data-theme` attribute drives the
  * CSS variables emitted by `@ghds/tokens/css`, so switching the Theme toolbar

--- a/apps/storybook-react/.storybook/preview.tsx
+++ b/apps/storybook-react/.storybook/preview.tsx
@@ -1,11 +1,13 @@
 import '@ghds/tokens/css';
 import type { Decorator, Preview } from '@storybook/react-vite';
+import isChromatic from 'chromatic/isChromatic';
 
 // GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
 // byte-deterministic across snapshot runs — otherwise every run re-rolls the
-// random seed and reports a false visual diff. Key mirrors
-// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
-if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+// random seed and reports a false visual diff. `isChromatic()` checks both the
+// user agent and the `chromatic=true` URL param (robust across Storybook types).
+// Key mirrors `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; dev stays random.
+if (isChromatic()) {
   (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
 }
 

--- a/apps/storybook-web-components/.storybook/preview.ts
+++ b/apps/storybook-web-components/.storybook/preview.ts
@@ -2,6 +2,14 @@ import '@ghds/tokens/css';
 import '@ghds/web-components';
 import type { Preview } from '@storybook/web-components';
 
+// GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
+// byte-deterministic across snapshot runs — otherwise every run re-rolls the
+// random seed and reports a false visual diff. Key mirrors
+// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
+if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+  (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
+}
+
 /**
  * Dark mode is a pure CSS-variable override. The decorator below sets
  * `data-theme` on <html>, exactly as a real consumer would, and the token

--- a/apps/storybook-web-components/.storybook/preview.ts
+++ b/apps/storybook-web-components/.storybook/preview.ts
@@ -1,12 +1,14 @@
 import '@ghds/tokens/css';
 import '@ghds/web-components';
 import type { Preview } from '@storybook/web-components';
+import isChromatic from 'chromatic/isChromatic';
 
 // GHD-45: pin the sketch PRNG seed under Chromatic so the hand-drawn geometry is
 // byte-deterministic across snapshot runs — otherwise every run re-rolls the
-// random seed and reports a false visual diff. Key mirrors
-// `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; production/dev stay random.
-if (typeof navigator !== 'undefined' && /\bChromatic\b/i.test(navigator.userAgent)) {
+// random seed and reports a false visual diff. `isChromatic()` checks both the
+// user agent and the `chromatic=true` URL param (robust across Storybook types).
+// Key mirrors `DETERMINISTIC_SEED_GLOBAL` in @ghds/sketch-core; dev stays random.
+if (isChromatic()) {
   (globalThis as Record<string, unknown>).__GHDS_SKETCH_SEED__ = 0x5eed;
 }
 

--- a/packages/react-native/src/sketch/options.test.ts
+++ b/packages/react-native/src/sketch/options.test.ts
@@ -1,3 +1,4 @@
+import { setForcedSeed } from '@ghds/sketch-core';
 import { describe, expect, it } from 'vitest';
 import { buildRectangleOutline, makeSeed, type SketchParams } from './options.js';
 
@@ -65,5 +66,15 @@ describe('makeSeed', () => {
   it('varies across instances mounted in the same tick', () => {
     const seeds = new Set(Array.from({ length: 50 }, () => makeSeed()));
     expect(seeds.size).toBeGreaterThan(1);
+  });
+
+  it('returns the host-pinned seed for snapshot determinism (GHD-45)', () => {
+    setForcedSeed(0x5eed);
+    try {
+      const seeds = new Set(Array.from({ length: 10 }, () => makeSeed()));
+      expect([...seeds]).toEqual([0x5eed]);
+    } finally {
+      setForcedSeed(null);
+    }
   });
 });

--- a/packages/react-native/src/sketch/options.ts
+++ b/packages/react-native/src/sketch/options.ts
@@ -1,4 +1,4 @@
-import { rectangle, type SketchDrawable, type SketchOptions } from '@ghds/sketch-core';
+import { forcedSeed, rectangle, type SketchDrawable, type SketchOptions } from '@ghds/sketch-core';
 
 /** Measured pixel size of a component, supplied by `onLayout`. */
 export interface Size {
@@ -78,8 +78,15 @@ let seedCounter = 0;
  * geometry core) owns seed creation; sketch-core then derives every random
  * decision deterministically from it, so re-renders never re-roll the look.
  * The counter disambiguates instances mounted within the same millisecond.
+ *
+ * When a host has pinned a seed (via `setForcedSeed`, e.g. Storybook under
+ * Chromatic) that value is returned instead, making snapshots deterministic.
  */
 export function makeSeed(): number {
+  const forced = forcedSeed();
+  if (forced !== null) {
+    return forced;
+  }
   seedCounter = (seedCounter + 1) >>> 0;
   const entropy = Math.floor(Math.random() * 0xffffffff);
   return (entropy ^ (Date.now() + seedCounter)) >>> 0;

--- a/packages/react/src/hooks/useSketch.test.tsx
+++ b/packages/react/src/hooks/useSketch.test.tsx
@@ -1,6 +1,7 @@
+import { setForcedSeed } from '@ghds/sketch-core';
 import { render } from '@testing-library/react';
 import { type JSX, useRef } from 'react';
-import { describe, expect, it } from 'vitest';
+import { afterEach, describe, expect, it } from 'vitest';
 import { type UseSketchResult, useSketch } from './useSketch.js';
 
 function capture(result: { current: UseSketchResult<HTMLDivElement> | null }) {
@@ -13,6 +14,8 @@ function capture(result: { current: UseSketchResult<HTMLDivElement> | null }) {
 }
 
 describe('useSketch', () => {
+  afterEach(() => setForcedSeed(null));
+
   it('generates deterministic geometry once a size is measured', () => {
     const result = { current: null as UseSketchResult<HTMLDivElement> | null };
     const Probe = capture(result);
@@ -42,5 +45,26 @@ describe('useSketch', () => {
     rerender(<Probe />);
     // Every observed seed value is identical (no per-render reshuffle).
     expect(new Set(seeds).size).toBe(1);
+  });
+
+  it('uses the host-pinned seed for snapshot determinism (GHD-45)', () => {
+    // With a forced seed, separate mounts must produce byte-identical geometry —
+    // this is what stops Chromatic from reporting false diffs every run.
+    setForcedSeed(0x5eed);
+    const a = { current: null as UseSketchResult<HTMLDivElement> | null };
+    const b = { current: null as UseSketchResult<HTMLDivElement> | null };
+    const ProbeA = capture(a);
+    const ProbeB = capture(b);
+    render(
+      <>
+        <ProbeA />
+        <ProbeB />
+      </>,
+    );
+
+    expect(a.current?.seed).toBe(0x5eed);
+    expect(b.current?.seed).toBe(0x5eed);
+    expect(a.current?.drawable?.strokePaths).toEqual(b.current?.drawable?.strokePaths);
+    expect(a.current?.drawable?.fillPaths).toEqual(b.current?.drawable?.fillPaths);
   });
 });

--- a/packages/react/src/hooks/useSketch.ts
+++ b/packages/react/src/hooks/useSketch.ts
@@ -1,4 +1,10 @@
-import { ellipse, rectangle, type SketchDrawable, type SketchOptions } from '@ghds/sketch-core';
+import {
+  ellipse,
+  forcedSeed,
+  rectangle,
+  type SketchDrawable,
+  type SketchOptions,
+} from '@ghds/sketch-core';
 import { useCallback, useMemo, useRef, useState } from 'react';
 
 /** Which sketch-core primitive to draw around the measured box. */
@@ -47,9 +53,9 @@ export interface UseSketchResult<E extends Element> {
   readonly seed: number;
 }
 
-/** A positive 31-bit seed. */
+/** A positive 31-bit seed, or the host-pinned seed when one is set (snapshots). */
 function randomSeed(): number {
-  return Math.floor(Math.random() * 0x7fffffff) + 1;
+  return forcedSeed() ?? Math.floor(Math.random() * 0x7fffffff) + 1;
 }
 
 /**

--- a/packages/sketch-core/src/index.ts
+++ b/packages/sketch-core/src/index.ts
@@ -7,5 +7,6 @@ export { linearizePath, path } from './geometry/path.js';
 export { polygon } from './geometry/polygon.js';
 export { rectangle } from './geometry/rectangle.js';
 export { mulberry32 } from './prng.js';
+export { DETERMINISTIC_SEED_GLOBAL, forcedSeed, setForcedSeed } from './seed.js';
 export { serialize } from './serialize.js';
 export type { Op, Point, SketchDrawable, SketchOptions } from './types.js';

--- a/packages/sketch-core/src/seed.test.ts
+++ b/packages/sketch-core/src/seed.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, describe, expect, it } from 'vitest';
+import { DETERMINISTIC_SEED_GLOBAL, forcedSeed, setForcedSeed } from './seed.js';
+
+describe('forced seed override', () => {
+  afterEach(() => setForcedSeed(null));
+
+  it('returns null when no seed is pinned', () => {
+    expect(forcedSeed()).toBeNull();
+  });
+
+  it('returns the pinned seed after setForcedSeed', () => {
+    setForcedSeed(1234);
+    expect(forcedSeed()).toBe(1234);
+    expect((globalThis as Record<string, unknown>)[DETERMINISTIC_SEED_GLOBAL]).toBe(1234);
+  });
+
+  it('clears the override with null', () => {
+    setForcedSeed(1234);
+    setForcedSeed(null);
+    expect(forcedSeed()).toBeNull();
+    expect(DETERMINISTIC_SEED_GLOBAL in (globalThis as Record<string, unknown>)).toBe(false);
+  });
+
+  it('ignores a non-finite pinned value', () => {
+    (globalThis as Record<string, unknown>)[DETERMINISTIC_SEED_GLOBAL] = Number.NaN;
+    expect(forcedSeed()).toBeNull();
+  });
+});

--- a/packages/sketch-core/src/seed.ts
+++ b/packages/sketch-core/src/seed.ts
@@ -1,0 +1,35 @@
+/**
+ * Deterministic-seed override.
+ *
+ * Each platform adapter (`@ghds/react`, `@ghds/web-components`,
+ * `@ghds/react-native`) generates a fresh random seed per component instance so
+ * hand-drawn output varies naturally. That randomness makes visual-regression
+ * snapshots (Storybook under Chromatic) flap: every run re-rolls the geometry
+ * and reports a false diff.
+ *
+ * A snapshot/test host can call {@link setForcedSeed} (typically guarded by a
+ * Chromatic/test check) to pin ONE seed for every sketch, making the geometry
+ * byte-deterministic across runs. Adapters read it via {@link forcedSeed} and
+ * fall back to their own `Math.random()` when it is unset — `Math.random()` is
+ * banned in this package, so the random fallback stays in the adapters.
+ *
+ * State lives on `globalThis` (not a module variable) so a single override
+ * applies across every package that imports its own copy of `@ghds/sketch-core`.
+ */
+export const DETERMINISTIC_SEED_GLOBAL = '__GHDS_SKETCH_SEED__';
+
+/** The forced seed if a host has pinned one, else `null` (use a random seed). */
+export function forcedSeed(): number | null {
+  const value = (globalThis as Record<string, unknown>)[DETERMINISTIC_SEED_GLOBAL];
+  return typeof value === 'number' && Number.isFinite(value) ? value : null;
+}
+
+/** Pin every sketch to `seed` (deterministic), or pass `null` to clear it. */
+export function setForcedSeed(seed: number | null): void {
+  const store = globalThis as Record<string, unknown>;
+  if (seed === null) {
+    delete store[DETERMINISTIC_SEED_GLOBAL];
+  } else {
+    store[DETERMINISTIC_SEED_GLOBAL] = seed;
+  }
+}

--- a/packages/web-components/src/sketchy-base.ts
+++ b/packages/web-components/src/sketchy-base.ts
@@ -1,4 +1,4 @@
-import type { SketchDrawable, SketchOptions } from '@ghds/sketch-core';
+import { forcedSeed, type SketchDrawable, type SketchOptions } from '@ghds/sketch-core';
 import { tokens } from '@ghds/tokens';
 import { type CSSResultGroup, css, html, LitElement, nothing, svg } from 'lit';
 import { property, state } from 'lit/decorators.js';
@@ -86,8 +86,11 @@ export abstract class SketchyBase extends LitElement {
   /** Measured frame height in CSS px (border box, rounded). */
   @state() protected sketchHeight = 0;
 
-  /** Random seed fixed once per instance; only used when `seed` is unset. */
-  private readonly autoSeed: number = Math.floor(Math.random() * 0x1_0000_0000);
+  /**
+   * Random seed fixed once per instance; only used when `seed` is unset. A
+   * host-pinned seed (via `setForcedSeed`, for snapshots) takes precedence.
+   */
+  private readonly autoSeed: number = forcedSeed() ?? Math.floor(Math.random() * 0x1_0000_0000);
   private resizeObserver?: ResizeObserver;
 
   /** The effective, lifetime-stable seed for this instance. */

--- a/packages/web-components/src/test/sketchy-base.test.ts
+++ b/packages/web-components/src/test/sketchy-base.test.ts
@@ -1,3 +1,4 @@
+import { setForcedSeed } from '@ghds/sketch-core';
 import { afterEach, describe, expect, it } from 'vitest';
 import { GhButton } from '../components/button.js';
 import { cleanup, mount, setSize } from './fixture.js';
@@ -33,6 +34,21 @@ describe('SketchyBase', () => {
     await setSize(a, 120, 40);
     await setSize(b, 120, 40);
     expect(strokeData(a)).toEqual(strokeData(b));
+  });
+
+  it('uses the host-pinned auto seed for snapshot determinism (GHD-45)', async () => {
+    // No explicit `seed` — two instances must still match because `autoSeed`
+    // picks up the host-pinned seed (what stops Chromatic false diffs).
+    setForcedSeed(0x5eed);
+    try {
+      const a = await mount(new GhButton());
+      const b = await mount(new GhButton());
+      await setSize(a, 120, 40);
+      await setSize(b, 120, 40);
+      expect(strokeData(a)).toEqual(strokeData(b));
+    } finally {
+      setForcedSeed(null);
+    }
   });
 
   it('does not regenerate geometry on unrelated re-renders (no jitter)', async () => {


### PR DESCRIPTION
## Problem (GHD-45)

Each adapter seeds the hand-drawn geometry per component instance with `Math.random()`, so Chromatic re-rolled every sketch on every run and reported **false visual diffs** — every PR (even a markdown-only one) needed all baselines re-accepted, and real regressions could hide in the noise. Surfaced during #25/#26.

## Fix

`@ghds/sketch-core` gains a deterministic-seed override:

- `forcedSeed(): number | null` and `setForcedSeed(seed | null)`, backed by a `globalThis.__GHDS_SKETCH_SEED__` key (so one override applies across every package).
- Adapters use the pinned seed when set, else their existing random fallback:
  - `@ghds/react` `useSketch`, `@ghds/react-native` `useSketch`/`makeSeed`, `@ghds/web-components` `SketchyBase.autoSeed`.
- `Math.random()` stays out of `sketch-core` (package rule) — only the override resolution lives there.
- Each Storybook preview pins a fixed seed **only under Chromatic** (`navigator.userAgent` check). Production and local dev remain random.

## Tests

- `sketch-core`: `seed.test.ts` (get/set/clear/non-finite).
- `@ghds/react`: `useSketch` test proving two separate mounts with a pinned seed produce **byte-identical** geometry.
- All four packages build + test + lint clean.

## Result

Chromatic snapshots become byte-deterministic — no more per-run false diffs / repeated baseline acceptance. After this merges, the recurring friction from #25/#26 goes away.

Fixes GHD-45.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a deterministic sketch seed override for more stable visual snapshots.
  * Storybook runs under Chromatic now use a fixed sketch seed so generated hand-drawn shapes stay consistent across captures.

* **Bug Fixes**
  * Reduced random seed differences across React, React Native, and web components when a seed is pinned.
  * Snapshot and regression tests now produce byte-identical geometry between runs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->