### PR TITLE
feat(icons): hand-drawn icon system — @ghds/icons + <Icon> (GHD-24)

### DIFF
--- a/.changeset/ghd-24-icon-system.md
+++ b/.changeset/ghd-24-icon-system.md
@@ -1,0 +1,13 @@
+---
+"@ghds/icons": minor
+"@ghds/tokens": minor
+"@ghds/react": minor
+---
+
+Add a hand-drawn icon system (GHD-24).
+
+- **New `@ghds/icons` package** — the single source of truth for iconography: 26 core icons as platform-agnostic SVG path `d` strings on a 24×24 grid, plus `iconSeed()` for stable per-name sketching. Zero runtime deps; sketched at render time via `@ghds/sketch-core` so icons match the rest of GHDS.
+- **`@ghds/tokens`** — adds `sys.icon.size` (`sm`/`md`/`lg` → 16/24/32px) and the `ref.iconSize` scale behind it.
+- **`@ghds/react`** — adds an `<Icon>` component consuming both, with deterministic per-name seeding, `currentColor` theming (inherits its context's color), accessible `label`/decorative modes, and a Storybook catalog of the full set.
+
+`@ghds/web-components` and `@ghds/react-native` renderers will consume the same `@ghds/icons` data in a follow-up.

--- a/packages/icons/CLAUDE.md
+++ b/packages/icons/CLAUDE.md
@@ -1,0 +1,39 @@
+# @ghds/icons — AGENTS.md
+
+> Package-specific guide. See the [root `AGENTS.md`](../../AGENTS.md) for the
+> project overview and the project-wide **Code Quality Gate**.
+
+Platform-agnostic **icon path data** for GHDS — the single source of truth for
+iconography. Mirrors the `@ghds/sketch-core` philosophy: **we ship data, not
+components.** Each icon is an SVG path `d` string; every renderer
+(`@ghds/react`, `@ghds/web-components`, `@ghds/react-native`) consumes the same
+string, runs it through `@ghds/sketch-core`'s `path()`, and paints it with
+token-driven color. Zero runtime dependencies, no DOM/framework imports.
+
+## Rules
+
+- **Geometry only.** Path strings carry no color, stroke width, or fill — those
+  come from `@ghds/tokens` in the renderer (`sys.color.icon`, size tokens). Never
+  put a design value in this package.
+- **24×24 grid.** Every path is authored on the `ICON_VIEWBOX` (24) grid so all
+  icons share one coordinate space. Prefer simple, stroke-based outlines (open
+  paths); curves/arcs are fine — sketch-core flattens them.
+- **Stable look, no `Math.random()`.** `iconSeed(name)` derives a deterministic
+  PRNG seed from the name, so an icon sketches identically everywhere (re-render,
+  SSR, snapshots, all platforms).
+- **Additive by default.** Adding an icon is a `minor`; renaming/removing one is
+  a breaking change — coordinate with the renderers and add a changeset.
+
+## Adding an icon
+
+1. Add `'<name>': '<d string>'` to `src/paths.ts` (24×24 grid, kebab-case name).
+2. `pnpm --filter @ghds/icons test` — the suite checks every path is well-formed.
+3. Add a changeset (`minor`).
+
+## Commands
+
+```bash
+pnpm build --filter @ghds/icons
+pnpm --filter @ghds/icons test
+pnpm lint --filter @ghds/icons
+```

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -1,0 +1,49 @@
+{
+  "name": "@ghds/icons",
+  "version": "0.0.0",
+  "description": "Platform-agnostic icon path data for GHDS — SVG `d` strings on a 24×24 grid, sketched at render time. Zero runtime deps.",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/GyeongHoKim/gyeongho-design-system.git",
+    "directory": "packages/icons"
+  },
+  "keywords": [
+    "design-system",
+    "icons",
+    "svg",
+    "sketchy",
+    "hand-drawn",
+    "ghds"
+  ],
+  "publishConfig": {
+    "access": "public",
+    "provenance": true
+  },
+  "type": "module",
+  "main": "./dist/index.js",
+  "module": "./dist/index.js",
+  "types": "./dist/index.d.ts",
+  "exports": {
+    ".": {
+      "types": "./dist/index.d.ts",
+      "default": "./dist/index.js"
+    }
+  },
+  "files": [
+    "dist"
+  ],
+  "scripts": {
+    "build": "tsc -p tsconfig.build.json",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "lint": "biome check .",
+    "clean": "rm -rf dist .turbo"
+  },
+  "devDependencies": {
+    "@ghds/tsconfig": "workspace:*",
+    "@types/node": "^24.0.0",
+    "typescript": "^6.0.0",
+    "vitest": "^3.0.0"
+  }
+}

--- a/packages/icons/src/index.test.ts
+++ b/packages/icons/src/index.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest';
+import { getIconPath, ICON_VIEWBOX, iconNames, iconPaths, iconSeed, isIconName } from './index.js';
+
+describe('@ghds/icons', () => {
+  it('exposes a non-empty, sorted list of icon names', () => {
+    expect(iconNames.length).toBeGreaterThan(0);
+    expect([...iconNames]).toEqual([...iconNames].sort());
+  });
+
+  it('every icon has a non-empty path string', () => {
+    for (const name of iconNames) {
+      expect(typeof iconPaths[name]).toBe('string');
+      expect(iconPaths[name].trim().length).toBeGreaterThan(0);
+      expect(iconPaths[name]).toMatch(/^M/); // a path starts with a moveto
+    }
+  });
+
+  it('isIconName narrows known vs unknown names', () => {
+    expect(isIconName('close')).toBe(true);
+    expect(isIconName('definitely-not-an-icon')).toBe(false);
+  });
+
+  it('getIconPath returns the same string as the map', () => {
+    expect(getIconPath('close')).toBe(iconPaths.close);
+  });
+
+  it('exposes the 24×24 authoring grid', () => {
+    expect(ICON_VIEWBOX).toBe(24);
+  });
+
+  describe('iconSeed', () => {
+    it('is deterministic for a given name', () => {
+      expect(iconSeed('search')).toBe(iconSeed('search'));
+    });
+
+    it('produces a positive 32-bit integer', () => {
+      for (const name of iconNames) {
+        const seed = iconSeed(name);
+        expect(Number.isInteger(seed)).toBe(true);
+        expect(seed).toBeGreaterThan(0);
+        expect(seed).toBeLessThanOrEqual(0xffffffff);
+      }
+    });
+
+    it('differs across most names (low collision)', () => {
+      const seeds = new Set(iconNames.map(iconSeed));
+      expect(seeds.size).toBe(iconNames.length);
+    });
+  });
+});

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -1,0 +1,40 @@
+import { iconPaths } from './paths.js';
+
+export { iconPaths } from './paths.js';
+
+/** The coordinate grid every icon path is authored on (`viewBox="0 0 24 24"`). */
+export const ICON_VIEWBOX = 24;
+
+/** A valid icon name (a key of {@link iconPaths}). */
+export type IconName = keyof typeof iconPaths;
+
+/** All icon names, sorted — handy for catalogs and tests. */
+export const iconNames = Object.keys(iconPaths).sort() as IconName[];
+
+/** Type guard: is `name` a known icon? */
+export function isIconName(name: string): name is IconName {
+  return Object.hasOwn(iconPaths, name);
+}
+
+/** Look up an icon's path `d` string, or `undefined` if the name is unknown. */
+export function getIconPath(name: IconName): string {
+  return iconPaths[name];
+}
+
+/**
+ * Deterministic PRNG seed for an icon, derived from its name (FNV-1a).
+ *
+ * Icons should look *stable* — the same icon renders with identical hand-drawn
+ * jitter everywhere (across re-renders, SSR, snapshots, and all three
+ * platforms) — so the seed is a pure function of the name rather than random.
+ * This keeps iconography consistent without any `Math.random()`.
+ */
+export function iconSeed(name: IconName): number {
+  let hash = 0x811c9dc5;
+  for (let i = 0; i < name.length; i++) {
+    hash ^= name.charCodeAt(i);
+    hash = Math.imul(hash, 0x01000193);
+  }
+  // Force an unsigned, non-zero 32-bit integer (0 is a poor PRNG seed).
+  return hash >>> 0 || 1;
+}

--- a/packages/icons/src/index.ts
+++ b/packages/icons/src/index.ts
@@ -16,7 +16,7 @@ export function isIconName(name: string): name is IconName {
   return Object.hasOwn(iconPaths, name);
 }
 
-/** Look up an icon's path `d` string, or `undefined` if the name is unknown. */
+/** Look up the path `d` string for a known {@link IconName}. */
 export function getIconPath(name: IconName): string {
   return iconPaths[name];
 }

--- a/packages/icons/src/paths.ts
+++ b/packages/icons/src/paths.ts
@@ -1,0 +1,40 @@
+/**
+ * Icon path data — the single source of truth for GHDS iconography.
+ *
+ * Every value is an SVG path `d` string authored on a **24×24 grid**
+ * ({@link ICON_VIEWBOX}). Paths are intentionally simple, stroke-based outlines:
+ * they carry geometry only (no color, no stroke width, no fill) and are meant to
+ * be run through `@ghds/sketch-core`'s `path()` at render time so they inherit
+ * the hand-drawn look. Renderers (`@ghds/react`, `@ghds/web-components`,
+ * `@ghds/react-native`) consume these strings and paint them with token colors.
+ *
+ * Curves and arcs are allowed — sketch-core flattens them before sketching.
+ */
+export const iconPaths = {
+  close: 'M6 6 L18 18 M6 18 L18 6',
+  check: 'M5 13 L10 18 L20 6',
+  plus: 'M12 5 L12 19 M5 12 L19 12',
+  minus: 'M5 12 L19 12',
+  'chevron-left': 'M15 5 L8 12 L15 19',
+  'chevron-right': 'M9 5 L16 12 L9 19',
+  'chevron-up': 'M5 15 L12 8 L19 15',
+  'chevron-down': 'M5 9 L12 16 L19 9',
+  'arrow-left': 'M20 12 L4 12 M10 6 L4 12 L10 18',
+  'arrow-right': 'M4 12 L20 12 M14 6 L20 12 L14 18',
+  'arrow-up': 'M12 20 L12 4 M6 10 L12 4 L18 10',
+  'arrow-down': 'M12 4 L12 20 M6 14 L12 20 L18 14',
+  menu: 'M4 7 L20 7 M4 12 L20 12 M4 17 L20 17',
+  search: 'M11 4 A7 7 0 1 0 11 18 A7 7 0 1 0 11 4 Z M16 16 L21 21',
+  home: 'M3 11 L12 3 L21 11 M6 9 L6 20 L18 20 L18 9',
+  user: 'M12 4 A4 4 0 1 0 12 12 A4 4 0 1 0 12 4 Z M5 20 C5 15 9 14 12 14 C15 14 19 15 19 20',
+  info: 'M12 3 A9 9 0 1 0 12 21 A9 9 0 1 0 12 3 Z M12 11 L12 16 M12 7.5 L12 8',
+  warning: 'M12 3 L22 20 L2 20 Z M12 9 L12 14 M12 16.5 L12 17',
+  trash: 'M4 7 L20 7 M9 7 L9 4 L15 4 L15 7 M6 7 L7 20 L17 20 L18 7 M10 11 L10 17 M14 11 L14 17',
+  star: 'M12 3 L14.7 9.2 L21 9.7 L16 14 L17.6 20.5 L12 17 L6.4 20.5 L8 14 L3 9.7 L9.3 9.2 Z',
+  heart: 'M12 20 C3 13 5 6 9 6 C11 6 12 8 12 9 C12 8 13 6 15 6 C19 6 21 13 12 20 Z',
+  'external-link': 'M13 4 L20 4 L20 11 M20 4 L11 13 M17 13 L17 20 L4 20 L4 7 L11 7',
+  mail: 'M3 6 L21 6 L21 18 L3 18 Z M3 6 L12 13 L21 6',
+  calendar: 'M4 6 L20 6 L20 20 L4 20 Z M4 10 L20 10 M8 4 L8 8 M16 4 L16 8',
+  eye: 'M2 12 C6 6 18 6 22 12 C18 18 6 18 2 12 Z M12 9 A3 3 0 1 0 12 15 A3 3 0 1 0 12 9 Z',
+  bell: 'M8 17 C8 17 6 16 6 11 C6 7 9 6 12 6 C15 6 18 7 18 11 C18 16 16 17 16 17 Z M10 20 L14 20',
+} as const;

--- a/packages/icons/tsconfig.build.json
+++ b/packages/icons/tsconfig.build.json
@@ -1,0 +1,5 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "./tsconfig.json",
+  "exclude": ["src/**/*.test.ts", "src/**/*.spec.ts"]
+}

--- a/packages/icons/tsconfig.json
+++ b/packages/icons/tsconfig.json
@@ -1,0 +1,9 @@
+{
+  "$schema": "https://json.schemastore.org/tsconfig",
+  "extends": "@ghds/tsconfig/node-library",
+  "compilerOptions": {
+    "outDir": "./dist",
+    "rootDir": "./src"
+  },
+  "include": ["src/**/*.ts"]
+}

--- a/packages/react/package.json
+++ b/packages/react/package.json
@@ -48,6 +48,7 @@
     "react-dom": ">=18"
   },
   "dependencies": {
+    "@ghds/icons": "workspace:*",
     "@ghds/sketch-core": "workspace:*",
     "@ghds/tokens": "workspace:*",
     "@radix-ui/react-label": "^2.1.0",

--- a/packages/react/src/components/Icon.stories.tsx
+++ b/packages/react/src/components/Icon.stories.tsx
@@ -1,0 +1,70 @@
+import { iconNames } from '@ghds/icons';
+import type { Meta, StoryObj } from '@storybook/react-vite';
+import { Icon } from './Icon.js';
+
+const meta = {
+  title: 'Components/Icon',
+  component: Icon,
+  args: { name: 'search', size: 'md' },
+  argTypes: {
+    name: { control: 'select', options: iconNames },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+} satisfies Meta<typeof Icon>;
+
+export default meta;
+
+type Story = StoryObj<typeof meta>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', alignItems: 'center', gap: 24 }}>
+      <Icon {...args} size="sm" />
+      <Icon {...args} size="md" />
+      <Icon {...args} size="lg" />
+    </div>
+  ),
+};
+
+/** Icons inherit their color from `currentColor` — here the container's text color. */
+export const InheritsColor: Story = {
+  render: (args) => (
+    <div style={{ display: 'flex', gap: 24, color: 'var(--sys-color-icon-danger)' }}>
+      <Icon {...args} name="trash" />
+      <Icon {...args} name="warning" />
+      <Icon {...args} name="close" />
+    </div>
+  ),
+};
+
+/** The full icon set — the catalog a designer or engineer browses to pick a name. */
+export const Catalog: Story = {
+  render: () => (
+    <div
+      style={{
+        display: 'grid',
+        gridTemplateColumns: 'repeat(auto-fill, minmax(96px, 1fr))',
+        gap: 16,
+        maxWidth: 720,
+      }}
+    >
+      {iconNames.map((name) => (
+        <div
+          key={name}
+          style={{
+            display: 'flex',
+            flexDirection: 'column',
+            alignItems: 'center',
+            gap: 8,
+            padding: 12,
+          }}
+        >
+          <Icon name={name} size="lg" />
+          <code style={{ fontSize: 11, textAlign: 'center' }}>{name}</code>
+        </div>
+      ))}
+    </div>
+  ),
+};

--- a/packages/react/src/components/Icon.test.tsx
+++ b/packages/react/src/components/Icon.test.tsx
@@ -1,0 +1,40 @@
+import { iconNames } from '@ghds/icons';
+import { render } from '@testing-library/react';
+import { describe, expect, it } from 'vitest';
+import { Icon } from './Icon.js';
+
+describe('Icon', () => {
+  it('renders a decorative sketch icon (aria-hidden) by default', () => {
+    const { container } = render(<Icon name="check" />);
+    const svg = container.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(svg).toHaveAttribute('aria-hidden', 'true');
+    expect(container.querySelectorAll('svg path').length).toBeGreaterThan(0);
+  });
+
+  it('exposes an accessible name when label is given', () => {
+    const { getByRole } = render(<Icon name="trash" label="Delete" />);
+    const img = getByRole('img', { name: 'Delete' });
+    expect(img.tagName.toLowerCase()).toBe('svg');
+  });
+
+  it('maps the size prop to a sys.icon.size token', () => {
+    const { container } = render(<Icon name="home" size="lg" />);
+    const svg = container.querySelector('svg');
+    expect(svg).toHaveAttribute('width', '32px');
+    expect(svg).toHaveAttribute('height', '32px');
+  });
+
+  it('is deterministic: same icon renders identical geometry across mounts', () => {
+    const a = render(<Icon name="star" />).container.querySelector('svg')?.innerHTML;
+    const b = render(<Icon name="star" />).container.querySelector('svg')?.innerHTML;
+    expect(a).toBe(b);
+  });
+
+  it('can render every icon in the set without error', () => {
+    for (const name of iconNames) {
+      const { container } = render(<Icon name={name} />);
+      expect(container.querySelectorAll('svg path').length).toBeGreaterThan(0);
+    }
+  });
+});

--- a/packages/react/src/components/Icon.tsx
+++ b/packages/react/src/components/Icon.tsx
@@ -1,0 +1,87 @@
+import { ICON_VIEWBOX, type IconName, iconPaths, iconSeed } from '@ghds/icons';
+import { path } from '@ghds/sketch-core';
+import { tokens } from '@ghds/tokens';
+import { type CSSProperties, forwardRef, type SVGAttributes, useMemo } from 'react';
+import { toPx } from '../lib/units.js';
+
+/** Semantic icon size, mapped to `sys.icon.size.*` tokens. */
+export type IconSize = 'sm' | 'md' | 'lg';
+
+export interface IconProps
+  extends Omit<SVGAttributes<SVGSVGElement>, 'children' | 'width' | 'height'> {
+  /** Which icon to render (a key of `@ghds/icons`). */
+  name: IconName;
+  /** Size role. Defaults to `'md'`. */
+  size?: IconSize;
+  /**
+   * Accessible name. When provided, the icon is exposed as `role="img"` with
+   * this label; when omitted, the icon is decorative (`aria-hidden`) and screen
+   * readers skip it — pair it with adjacent text in that case.
+   */
+  label?: string;
+}
+
+// Sketch numerics are theme-independent, so they come from the raw token object.
+// The stroke color defaults to `currentColor` so an icon adopts its context's
+// text color (e.g. a button label); consumers override via `color`/CSS.
+const ROUGHNESS = tokens.sys.sketch.roughness;
+const BOWING = tokens.sys.sketch.bowing;
+const STROKE_WIDTH = toPx(tokens.sys.border.width.default);
+
+/**
+ * A hand-drawn icon. The path geometry is the single source of truth in
+ * `@ghds/icons`; it is sketched at render time by `@ghds/sketch-core` (so it
+ * matches the rest of GHDS) and sized from `sys.icon.size` tokens. The seed is
+ * derived from the icon name, so every instance of an icon looks identical
+ * (deterministic across re-renders, SSR and snapshots).
+ */
+export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
+  { name, size = 'md', label, style, ...rest },
+  ref,
+) {
+  const drawable = useMemo(
+    () => path(iconPaths[name], { roughness: ROUGHNESS, bowing: BOWING, seed: iconSeed(name) }),
+    [name],
+  );
+
+  const dimension = tokens.sys.icon.size[size];
+  const rootStyle: CSSProperties = {
+    display: 'inline-block',
+    flexShrink: 0,
+    verticalAlign: 'middle',
+    color: 'currentColor',
+    ...style,
+  };
+
+  return (
+    <svg
+      ref={ref}
+      width={dimension}
+      height={dimension}
+      viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
+      fill="none"
+      // Labelled icons are exposed as images; unlabelled ones are decorative and
+      // hidden from assistive tech (pair them with adjacent text).
+      role={label ? 'img' : undefined}
+      aria-label={label}
+      aria-hidden={label ? undefined : true}
+      focusable={false}
+      style={rootStyle}
+      {...rest}
+    >
+      {label ? <title>{label}</title> : null}
+      {drawable.strokePaths.map((d, i) => (
+        <path
+          // biome-ignore lint/suspicious/noArrayIndexKey: paths are a fixed, ordered IR list
+          key={i}
+          d={d}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={STROKE_WIDTH}
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+    </svg>
+  );
+});

--- a/packages/react/src/components/Icon.tsx
+++ b/packages/react/src/components/Icon.tsx
@@ -56,6 +56,10 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
   return (
     <svg
       ref={ref}
+      // `...rest` is spread first so the token-driven sizing and the computed
+      // accessibility contract below always win — a consumer can't silently
+      // override `role`/`aria-*` (use the `label` prop to name an icon).
+      {...rest}
       width={dimension}
       height={dimension}
       viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
@@ -67,7 +71,6 @@ export const Icon = forwardRef<SVGSVGElement, IconProps>(function Icon(
       aria-hidden={label ? undefined : true}
       focusable={false}
       style={rootStyle}
-      {...rest}
     >
       {label ? <title>{label}</title> : null}
       {drawable.strokePaths.map((d, i) => (

--- a/packages/react/src/index.ts
+++ b/packages/react/src/index.ts
@@ -1,5 +1,7 @@
+export type { IconName } from '@ghds/icons';
 export { Button, type ButtonProps, type ButtonVariant } from './components/Button.js';
 export { Card, type CardProps } from './components/Card.js';
+export { Icon, type IconProps, type IconSize } from './components/Icon.js';
 export { Input, type InputProps } from './components/Input.js';
 export {
   type FillRendering,

--- a/packages/tokens/src/ref/dimension.json
+++ b/packages/tokens/src/ref/dimension.json
@@ -31,6 +31,13 @@
       "thin": { "$value": "1px" },
       "medium": { "$value": "2px" },
       "thick": { "$value": "3px" }
+    },
+    "iconSize": {
+      "$type": "dimension",
+      "$description": "Tier 1 icon size scale.",
+      "sm": { "$value": "16px" },
+      "md": { "$value": "24px" },
+      "lg": { "$value": "32px" }
     }
   }
 }

--- a/packages/tokens/src/sys/_shared.json
+++ b/packages/tokens/src/sys/_shared.json
@@ -106,6 +106,15 @@
       "hachureGap": { "$value": "{ref.sketch.hachureGap.default}" },
       "hachureAngle": { "$value": "{ref.sketch.hachureAngle.default}" },
       "elevation": { "$value": "{ref.sketch.elevation.raised}" }
+    },
+    "icon": {
+      "size": {
+        "$type": "dimension",
+        "$description": "Tier 2 semantic icon sizes. Theme-invariant.",
+        "sm": { "$value": "{ref.iconSize.sm}" },
+        "md": { "$value": "{ref.iconSize.md}" },
+        "lg": { "$value": "{ref.iconSize.lg}" }
+      }
     }
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -202,8 +202,26 @@ importers:
         specifier: ^3.0.0
         version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.48.0)(yaml@2.9.0)
 
+  packages/icons:
+    devDependencies:
+      '@ghds/tsconfig':
+        specifier: workspace:*
+        version: link:../tsconfig
+      '@types/node':
+        specifier: ^24.0.0
+        version: 24.13.2
+      typescript:
+        specifier: ^6.0.0
+        version: 6.0.3
+      vitest:
+        specifier: ^3.0.0
+        version: 3.2.6(@types/debug@4.1.13)(@types/node@24.13.2)(jiti@2.6.1)(jsdom@26.1.0)(terser@5.48.0)(yaml@2.9.0)
+
   packages/react:
     dependencies:
+      '@ghds/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@ghds/sketch-core':
         specifier: workspace:*
         version: link:../sketch-core


### PR DESCRIPTION
First increment of the icon system (GHD-24). Follows the proven GHDS pattern: **share data, not components** — one platform-agnostic source, thin per-platform renderers.

## What's here

- **New `@ghds/icons` package** — single source of truth: **26 core icons** as SVG path `d` strings on a 24×24 grid (close, check, arrows, chevrons, menu, search, home, user, mail, calendar, bell, trash, star, heart, warning, info, eye, external-link, …). `iconSeed(name)` derives a deterministic per-name seed → an icon looks identical everywhere (re-render, SSR, snapshots, all platforms). Zero runtime deps.
- **`@ghds/tokens`** — adds `sys.icon.size` (`sm`/`md`/`lg` → 16/24/32px) + `ref.iconSize`.
- **`@ghds/react`** — `<Icon name size label>` consuming `@ghds/icons` + `@ghds/sketch-core` `path()` + size tokens. `currentColor` theming (an icon adopts its context's color), accessible (`label` → `role=img`; decorative → `aria-hidden`). Storybook **Catalog** story browses the full set.

## Architecture note (RN can't use web components)
A single web component can't serve all three targets — **React Native has no DOM**, so it always needs its own renderer. The single source is therefore the *data* (`@ghds/icons`), exactly like `@ghds/sketch-core`. Each platform stays an independent thin renderer (like Button/Card/Input).

## Verification
- Rendered all 26 icons through sketch-core in a headless browser — every icon is recognizable and carries the hand-drawn look. ✅
- `@ghds/icons` 8 tests · `@ghds/tokens` 90 (validation) · `@ghds/react` 26 (incl. Icon: a11y, size→token, determinism, renders every icon). Lint + build clean.

## ⚠️ Release prerequisite (new package)
`@ghds/icons` is a **new npm package**. Per GHD-18, its first publish needs a one-time **OIDC trusted-publisher registration on npmjs** (like the original 5 packages). Until that's set up, the release pipeline's `changeset publish` will fail on this package (and `@ghds/react` depends on it). **Please register `@ghds/icons` before merging the resulting Version Packages PR.** The code here is reviewable/mergeable independently.

## Follow-ups
- `@ghds/web-components` `<gh-icon>` + `@ghds/react-native` `<Icon>` (same `@ghds/icons` data).
- Website Foundations → Iconography page (ties into M8 / GHD-27).

Part of GHD-24.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Launched the hand-drawn icon system (GHD-24) with a shared icon catalog and deterministic rendering across platforms.
  * Added an `Icon` component with `sm|md|lg` sizing, `currentColor` theming, and support for labeled (accessible) and decorative usage modes.
  * Included Storybook stories to preview individual icons, sizes, and the full catalog.
* **Bug Fixes**
  * Added standardized icon sizing tokens (`sm`/`md`/`lg`) for consistent icon dimensions.
* **Documentation**
  * Documented the new icon authoring and contribution rules for the icon catalog.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->