### PR TITLE
feat(icons): Icon renderers for web-components + react-native (GHD-24)

### DIFF
--- a/.changeset/ghd-24-icon-wc-rn.md
+++ b/.changeset/ghd-24-icon-wc-rn.md
@@ -1,0 +1,6 @@
+---
+"@ghds/web-components": minor
+"@ghds/react-native": minor
+---
+
+Add the `Icon` renderer to the remaining platforms (GHD-24). `@ghds/web-components` ships `<gh-icon name size label>` and `@ghds/react-native` ships `<Icon>`, both consuming the same `@ghds/icons` path data through `@ghds/sketch-core` with the deterministic per-name seed — so an icon looks identical across React, web components and React Native. Sizes come from `sys.icon.size`; color inherits `currentColor` (web) / defaults to `sys.color.icon.default` (RN).

--- a/apps/storybook-react-native/src/Icon.stories.tsx
+++ b/apps/storybook-react-native/src/Icon.stories.tsx
@@ -1,5 +1,4 @@
-import { iconNames } from '@ghds/icons';
-import { Box, Icon, Text } from '@ghds/react-native';
+import { Box, Icon, iconNames, Text } from '@ghds/react-native';
 import type { Meta, StoryObj } from '@storybook/react';
 
 const meta: Meta<typeof Icon> = {

--- a/apps/storybook-react-native/src/Icon.stories.tsx
+++ b/apps/storybook-react-native/src/Icon.stories.tsx
@@ -1,0 +1,41 @@
+import { iconNames } from '@ghds/icons';
+import { Box, Icon, Text } from '@ghds/react-native';
+import type { Meta, StoryObj } from '@storybook/react';
+
+const meta: Meta<typeof Icon> = {
+  title: 'Components/Icon',
+  component: Icon,
+  args: { name: 'search', size: 'md' },
+  argTypes: {
+    name: { control: 'select', options: iconNames },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+  },
+};
+
+export default meta;
+type Story = StoryObj<typeof Icon>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => (
+    <Box flexDirection="row" alignItems="center" gap="lg">
+      <Icon {...args} size="sm" />
+      <Icon {...args} size="md" />
+      <Icon {...args} size="lg" />
+    </Box>
+  ),
+};
+
+export const Catalog: Story = {
+  render: () => (
+    <Box flexDirection="row" flexWrap="wrap" gap="md">
+      {iconNames.map((name) => (
+        <Box key={name} alignItems="center" gap="xs" padding="sm" width={88}>
+          <Icon name={name} size="lg" />
+          <Text variant="caption">{name}</Text>
+        </Box>
+      ))}
+    </Box>
+  ),
+};

--- a/apps/storybook-web-components/src/icon.stories.ts
+++ b/apps/storybook-web-components/src/icon.stories.ts
@@ -1,4 +1,4 @@
-import { iconNames } from '@ghds/icons';
+import { iconNames } from '@ghds/web-components';
 import type { Meta, StoryObj } from '@storybook/web-components';
 import { html } from 'lit';
 

--- a/apps/storybook-web-components/src/icon.stories.ts
+++ b/apps/storybook-web-components/src/icon.stories.ts
@@ -1,0 +1,68 @@
+import { iconNames } from '@ghds/icons';
+import type { Meta, StoryObj } from '@storybook/web-components';
+import { html } from 'lit';
+
+interface IconArgs {
+  name: string;
+  size: 'sm' | 'md' | 'lg';
+  label: string;
+}
+
+const meta: Meta<IconArgs> = {
+  title: 'Components/Icon',
+  tags: ['autodocs'],
+  render: (args) =>
+    html`<gh-icon name=${args.name} size=${args.size} label=${args.label}></gh-icon>`,
+  args: { name: 'search', size: 'md', label: '' },
+  argTypes: {
+    name: { control: 'select', options: iconNames },
+    size: { control: 'inline-radio', options: ['sm', 'md', 'lg'] },
+    label: { control: 'text' },
+  },
+};
+
+export default meta;
+type Story = StoryObj<IconArgs>;
+
+export const Default: Story = {};
+
+export const Sizes: Story = {
+  render: (args) => html`
+    <div style="display: flex; align-items: center; gap: 24px;">
+      <gh-icon name=${args.name} size="sm"></gh-icon>
+      <gh-icon name=${args.name} size="md"></gh-icon>
+      <gh-icon name=${args.name} size="lg"></gh-icon>
+    </div>
+  `,
+};
+
+/** Icons inherit `currentColor` — here the container's text color. */
+export const InheritsColor: Story = {
+  render: () => html`
+    <div style="display: flex; gap: 24px; color: var(--sys-color-icon-danger);">
+      <gh-icon name="trash"></gh-icon>
+      <gh-icon name="warning"></gh-icon>
+      <gh-icon name="close"></gh-icon>
+    </div>
+  `,
+};
+
+/** The full icon set — the catalog for browsing names. */
+export const Catalog: Story = {
+  render: () => html`
+    <div
+      style="display: grid; grid-template-columns: repeat(auto-fill, minmax(96px, 1fr)); gap: 16px; max-width: 720px;"
+    >
+      ${iconNames.map(
+        (name) => html`
+          <div
+            style="display: flex; flex-direction: column; align-items: center; gap: 8px; padding: 12px;"
+          >
+            <gh-icon name=${name} size="lg"></gh-icon>
+            <code style="font-size: 11px; text-align: center;">${name}</code>
+          </div>
+        `,
+      )}
+    </div>
+  `,
+};

--- a/packages/react-native/package.json
+++ b/packages/react-native/package.json
@@ -47,6 +47,7 @@
     "react-native-svg": ">=15.0.0"
   },
   "dependencies": {
+    "@ghds/icons": "workspace:*",
     "@ghds/sketch-core": "workspace:*",
     "@ghds/tokens": "workspace:*",
     "@shopify/restyle": "^2.4.5"

--- a/packages/react-native/src/components/Icon.test.tsx
+++ b/packages/react-native/src/components/Icon.test.tsx
@@ -1,0 +1,31 @@
+import { iconNames } from '@ghds/icons';
+import { describe, expect, it } from 'vitest';
+import { renderWithTheme } from '../test-utils.js';
+import { Icon } from './Icon.js';
+
+describe('Icon', () => {
+  it('renders an svg with sketch path geometry', () => {
+    const { container } = renderWithTheme(<Icon name="check" />);
+    expect(container.querySelector('svg')).not.toBeNull();
+    expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+  });
+
+  it('sizes the svg from the icon-size token (lg → 32)', () => {
+    const { container } = renderWithTheme(<Icon name="home" size="lg" />);
+    expect(container.querySelector('svg')?.getAttribute('width')).toBe('32');
+  });
+
+  it('renders identical geometry for the same icon (deterministic seed)', () => {
+    const a = renderWithTheme(<Icon name="star" />).container.querySelector('svg')?.innerHTML;
+    const b = renderWithTheme(<Icon name="star" />).container.querySelector('svg')?.innerHTML;
+    expect(a).toBe(b);
+  });
+
+  it('renders every icon in the set without error', () => {
+    for (const name of iconNames) {
+      const { container, unmount } = renderWithTheme(<Icon name={name} />);
+      expect(container.querySelectorAll('path').length).toBeGreaterThan(0);
+      unmount();
+    }
+  });
+});

--- a/packages/react-native/src/components/Icon.tsx
+++ b/packages/react-native/src/components/Icon.tsx
@@ -1,0 +1,74 @@
+import { ICON_VIEWBOX, type IconName, iconPaths, iconSeed } from '@ghds/icons';
+import { path } from '@ghds/sketch-core';
+import { useTheme } from '@shopify/restyle';
+import { useMemo } from 'react';
+import Svg, { Path } from 'react-native-svg';
+import type { Theme } from '../theme/theme.js';
+
+/** Semantic icon size, mapped to `sys.icon.size.*` theme tokens. */
+export type IconSize = 'sm' | 'md' | 'lg';
+
+/** Props for {@link Icon}. */
+export interface IconProps {
+  /** Which icon to render (a key of `@ghds/icons`). */
+  name: IconName;
+  /** Size role. Defaults to `'md'`. */
+  size?: IconSize;
+  /**
+   * Stroke color (a token hex value). Defaults to the `iconDefault` theme color.
+   */
+  color?: string;
+  /**
+   * Accessible label. When set, the icon is exposed as an image with this label;
+   * otherwise it is decorative and hidden from assistive tech.
+   */
+  label?: string;
+  /** Test handle for queries. */
+  testID?: string;
+}
+
+/**
+ * A hand-drawn icon. The path geometry is the single source of truth in
+ * `@ghds/icons`; it is sketched by `@ghds/sketch-core` (so it matches the rest
+ * of GHDS) and rendered via `react-native-svg` — the only platform difference
+ * from the web adapter. Size and default color come from `@ghds/tokens` (via the
+ * Restyle theme). The seed is derived from the icon name, so an icon looks
+ * identical everywhere.
+ */
+export function Icon({ name, size = 'md', color, label, testID }: IconProps) {
+  const theme = useTheme<Theme>();
+  const { roughness, bowing } = theme.sketch;
+
+  const drawable = useMemo(
+    () => path(iconPaths[name], { roughness, bowing, seed: iconSeed(name) }),
+    [name, roughness, bowing],
+  );
+
+  const dimension = theme.iconSizes[size];
+  const stroke = color ?? theme.colors.iconDefault;
+
+  return (
+    <Svg
+      testID={testID}
+      width={dimension}
+      height={dimension}
+      viewBox={`0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}`}
+      accessibilityRole={label ? 'image' : undefined}
+      accessibilityLabel={label}
+      accessibilityElementsHidden={label ? undefined : true}
+      importantForAccessibility={label ? 'auto' : 'no-hide-descendants'}
+    >
+      {drawable.strokePaths.map((d) => (
+        <Path
+          key={`stroke:${d}`}
+          d={d}
+          stroke={stroke}
+          strokeWidth={theme.borderWidths.default}
+          fill="none"
+          strokeLinecap="round"
+          strokeLinejoin="round"
+        />
+      ))}
+    </Svg>
+  );
+}

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -7,11 +7,14 @@
  * `darkTheme` (the host app chooses; this library ships both).
  */
 
+export type { IconName } from '@ghds/icons';
 export { ThemeProvider } from '@shopify/restyle';
 export type { ButtonProps, ButtonVariant } from './components/Button.js';
 export { Button } from './components/Button.js';
 export type { CardProps } from './components/Card.js';
 export { Card } from './components/Card.js';
+export type { IconProps, IconSize } from './components/Icon.js';
+export { Icon } from './components/Icon.js';
 export type { InputProps } from './components/Input.js';
 export { Input } from './components/Input.js';
 export type { Size, SketchParams } from './sketch/options.js';

--- a/packages/react-native/src/index.ts
+++ b/packages/react-native/src/index.ts
@@ -7,7 +7,7 @@
  * `darkTheme` (the host app chooses; this library ships both).
  */
 
-export type { IconName } from '@ghds/icons';
+export { type IconName, iconNames } from '@ghds/icons';
 export { ThemeProvider } from '@shopify/restyle';
 export type { ButtonProps, ButtonVariant } from './components/Button.js';
 export { Button } from './components/Button.js';

--- a/packages/react-native/src/theme/theme.ts
+++ b/packages/react-native/src/theme/theme.ts
@@ -109,6 +109,11 @@ function buildTheme(t: Tokens) {
       default: t.sys.border.width.default,
       thick: t.sys.border.width.thick,
     },
+    iconSizes: {
+      sm: t.sys.icon.size.sm,
+      md: t.sys.icon.size.md,
+      lg: t.sys.icon.size.lg,
+    },
     textVariants: {
       defaults: toTextVariant(t.sys.typography.body),
       heading: toTextVariant(t.sys.typography.heading),

--- a/packages/web-components/package.json
+++ b/packages/web-components/package.json
@@ -46,6 +46,7 @@
     "clean": "rm -rf dist .turbo"
   },
   "dependencies": {
+    "@ghds/icons": "workspace:*",
     "@ghds/sketch-core": "workspace:*",
     "@ghds/tokens": "workspace:*",
     "lit": "^3.2.1"

--- a/packages/web-components/src/components/icon.ts
+++ b/packages/web-components/src/components/icon.ts
@@ -1,0 +1,93 @@
+import { ICON_VIEWBOX, type IconName, iconPaths, iconSeed } from '@ghds/icons';
+import { path } from '@ghds/sketch-core';
+import { tokens } from '@ghds/tokens';
+import { css, html, LitElement, nothing, svg } from 'lit';
+import { customElement, property } from 'lit/decorators.js';
+
+/** Semantic icon size, mapped to `sys.icon.size.*` tokens via CSS. */
+export type GhIconSize = 'sm' | 'md' | 'lg';
+
+/**
+ * `<gh-icon>` — a hand-drawn icon.
+ *
+ * The path geometry is the single source of truth in `@ghds/icons`; it is
+ * sketched at render time by `@ghds/sketch-core` (so it matches the rest of
+ * GHDS) and sized from `sys.icon.size` tokens. The seed is derived from the icon
+ * name, so every instance of an icon looks identical. Colours come from
+ * `currentColor` (defaulting to `sys.color.icon.default`), so an icon adopts its
+ * context's colour just like text.
+ */
+@customElement('gh-icon')
+export class GhIcon extends LitElement {
+  static override styles = css`
+    :host {
+      display: inline-flex;
+      color: var(--sys-color-icon-default);
+    }
+
+    svg {
+      display: block;
+      width: var(--sys-icon-size-md);
+      height: var(--sys-icon-size-md);
+    }
+
+    :host([size='sm']) svg {
+      width: var(--sys-icon-size-sm);
+      height: var(--sys-icon-size-sm);
+    }
+
+    :host([size='lg']) svg {
+      width: var(--sys-icon-size-lg);
+      height: var(--sys-icon-size-lg);
+    }
+
+    path {
+      fill: none;
+      stroke: currentColor;
+      stroke-width: var(--sys-border-width-default);
+      stroke-linecap: round;
+      stroke-linejoin: round;
+    }
+  `;
+
+  /** Which icon to render (a key of `@ghds/icons`). */
+  @property() name!: IconName;
+
+  /** Size role. Defaults to `'md'`. */
+  @property({ reflect: true }) size: GhIconSize = 'md';
+
+  /**
+   * Accessible name. When set, the icon is exposed as an image with this label;
+   * otherwise it is decorative and hidden from assistive tech.
+   */
+  @property() label?: string;
+
+  protected override render(): unknown {
+    const d = iconPaths[this.name];
+    if (d === undefined) {
+      return nothing;
+    }
+    const drawable = path(d, {
+      roughness: tokens.sys.sketch.roughness,
+      bowing: tokens.sys.sketch.bowing,
+      seed: iconSeed(this.name),
+    });
+    return html`<svg
+      viewBox="0 0 ${ICON_VIEWBOX} ${ICON_VIEWBOX}"
+      fill="none"
+      role=${this.label ? 'img' : nothing}
+      aria-label=${this.label ?? nothing}
+      aria-hidden=${this.label ? nothing : 'true'}
+      focusable="false"
+    >
+      ${this.label ? svg`<title>${this.label}</title>` : nothing}
+      ${drawable.strokePaths.map((pd) => svg`<path d=${pd}></path>`)}
+    </svg>`;
+  }
+}
+
+declare global {
+  interface HTMLElementTagNameMap {
+    'gh-icon': GhIcon;
+  }
+}

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,6 +1,9 @@
+export type { IconName } from '@ghds/icons';
 export type { GhButtonType, GhButtonVariant } from './components/button.js';
 export { GhButton } from './components/button.js';
 export { GhCard } from './components/card.js';
+export type { GhIconSize } from './components/icon.js';
+export { GhIcon } from './components/icon.js';
 export type { GhInputType } from './components/input.js';
 export { GhInput } from './components/input.js';
 export type { SketchParams } from './sketchy-base.js';

--- a/packages/web-components/src/index.ts
+++ b/packages/web-components/src/index.ts
@@ -1,4 +1,4 @@
-export type { IconName } from '@ghds/icons';
+export { type IconName, iconNames } from '@ghds/icons';
 export type { GhButtonType, GhButtonVariant } from './components/button.js';
 export { GhButton } from './components/button.js';
 export { GhCard } from './components/card.js';

--- a/packages/web-components/src/test/icon.test.ts
+++ b/packages/web-components/src/test/icon.test.ts
@@ -1,0 +1,61 @@
+import { iconNames } from '@ghds/icons';
+import { afterEach, describe, expect, it } from 'vitest';
+import { GhIcon } from '../components/icon.js';
+import { cleanup, mount } from './fixture.js';
+
+function paths(el: GhIcon): NodeListOf<SVGPathElement> {
+  return el.shadowRoot?.querySelectorAll('path') ?? ([] as unknown as NodeListOf<SVGPathElement>);
+}
+
+describe('gh-icon', () => {
+  afterEach(cleanup);
+
+  it('registers as a custom element', () => {
+    expect(customElements.get('gh-icon')).toBe(GhIcon);
+  });
+
+  it('renders sketch <path> geometry for a named icon', async () => {
+    const el = new GhIcon();
+    el.name = 'check';
+    await mount(el);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg).not.toBeNull();
+    expect(paths(el).length).toBeGreaterThan(0);
+  });
+
+  it('is decorative (aria-hidden) without a label', async () => {
+    const el = new GhIcon();
+    el.name = 'trash';
+    await mount(el);
+    expect(el.shadowRoot?.querySelector('svg')?.getAttribute('aria-hidden')).toBe('true');
+  });
+
+  it('exposes an accessible image role + label when labelled', async () => {
+    const el = new GhIcon();
+    el.name = 'trash';
+    el.label = 'Delete';
+    await mount(el);
+    const svg = el.shadowRoot?.querySelector('svg');
+    expect(svg?.getAttribute('role')).toBe('img');
+    expect(svg?.getAttribute('aria-label')).toBe('Delete');
+    expect(el.shadowRoot?.querySelector('title')?.textContent).toBe('Delete');
+  });
+
+  it('reflects the size attribute for token-driven sizing', async () => {
+    const el = new GhIcon();
+    el.name = 'home';
+    el.size = 'lg';
+    await mount(el);
+    expect(el.getAttribute('size')).toBe('lg');
+  });
+
+  it('renders every icon in the set without error', async () => {
+    for (const name of iconNames) {
+      const el = new GhIcon();
+      el.name = name;
+      await mount(el);
+      expect(paths(el).length).toBeGreaterThan(0);
+      el.remove();
+    }
+  });
+});

--- a/packages/web-components/src/test/icon.test.ts
+++ b/packages/web-components/src/test/icon.test.ts
@@ -58,4 +58,25 @@ describe('gh-icon', () => {
       el.remove();
     }
   });
+
+  it('is theme-invariant: identical geometry in light and dark schemes', async () => {
+    // Icon colour comes from `currentColor` (a `sys.color.icon` CSS var), so only
+    // the colour re-themes — the sketched geometry must be byte-identical, and an
+    // icon never re-rolls its look when the ancestor `data-theme` flips.
+    const light = new GhIcon();
+    light.name = 'star';
+    document.documentElement.setAttribute('data-theme', 'light');
+    await mount(light);
+    const lightGeometry = Array.from(paths(light), (p) => p.getAttribute('d'));
+
+    const dark = new GhIcon();
+    dark.name = 'star';
+    document.documentElement.setAttribute('data-theme', 'dark');
+    await mount(dark);
+    const darkGeometry = Array.from(paths(dark), (p) => p.getAttribute('d'));
+
+    document.documentElement.removeAttribute('data-theme');
+    expect(darkGeometry).toEqual(lightGeometry);
+    expect(lightGeometry.length).toBeGreaterThan(0);
+  });
 });

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -280,6 +280,9 @@ importers:
 
   packages/react-native:
     dependencies:
+      '@ghds/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@ghds/sketch-core':
         specifier: workspace:*
         version: link:../sketch-core
@@ -370,6 +373,9 @@ importers:
 
   packages/web-components:
     dependencies:
+      '@ghds/icons':
+        specifier: workspace:*
+        version: link:../icons
       '@ghds/sketch-core':
         specifier: workspace:*
         version: link:../sketch-core


### PR DESCRIPTION
Completes the cross-platform icon system (GHD-24): the remaining two renderers, both consuming the **same `@ghds/icons` path data** through `@ghds/sketch-core` with the deterministic per-name seed — so an icon looks identical across React, web components and React Native. Follows the "share data, not components" architecture (React `<Icon>` shipped in #30).

## What's here
- **`@ghds/web-components`** — `<gh-icon name size label>` (Lit). Sized via CSS from `sys.icon.size` (`[size]` reflected), `currentColor` theming defaulting to `sys.color.icon.default`, sketch stroke from `sys.border.width.default`. Accessible: `label` → `role=img` + `<title>`; decorative → `aria-hidden`.
- **`@ghds/react-native`** — `<Icon>` via `react-native-svg`. Size + default color from the Restyle theme (adds `theme.iconSizes` mapped from `sys.icon.size`); `color` override prop. RN a11y (`accessibilityRole="image"` / hidden when decorative).
- Storybook **Catalog** + **Sizes** stories and unit tests for both (every icon renders; deterministic geometry; token-driven size).

## Notes
- No new tokens/data — reuses `@ghds/icons@0.1.0` + `sys.icon.size` from #30.
- Geometry is byte-identical to the React renderer (same data + engine + `iconSeed`), so it needs no separate visual re-verification.
- Web components can't run in React Native (no DOM), which is exactly why the shared unit is the data — RN keeps its own thin `react-native-svg` renderer.

Completes GHD-24 (all three platforms).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an `Icon` component for both web and React Native with consistent sizing, coloring, and accessible labeling behavior.
  * Expanded Storybook coverage with interactive icon catalogs, size variants, and color-inheritance examples.
* **Bug Fixes**
  * Standardized icon sizing and coloring across platforms, with deterministic icon rendering so the same name looks identical.
* **Tests**
  * Added automated coverage for SVG rendering, sizing, accessibility states, deterministic output, and rendering the full icon set.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->