### PR TITLE
fix(website): translate promotional site to English (GHD-43)

### DIFF
--- a/apps/website/src/components/LitDemo.astro
+++ b/apps/website/src/components/LitDemo.astro
@@ -9,25 +9,25 @@
   <div>
     <p class="demo-label">Button</p>
     <div class="demo-row">
-      <gh-button variant="primary">기본</gh-button>
-      <gh-button variant="danger">위험</gh-button>
-      <gh-button variant="neutral">중립</gh-button>
-      <gh-button variant="primary" disabled>비활성</gh-button>
+      <gh-button variant="primary">Default</gh-button>
+      <gh-button variant="danger">Danger</gh-button>
+      <gh-button variant="neutral">Neutral</gh-button>
+      <gh-button variant="primary" disabled>Disabled</gh-button>
     </div>
   </div>
 
   <div>
     <p class="demo-label">Input</p>
     <div class="demo-stack">
-      <gh-input label="이메일" placeholder="you@example.com" type="email"></gh-input>
-      <gh-input label="비밀번호" type="password" required></gh-input>
+      <gh-input label="Email" placeholder="you@example.com" type="email"></gh-input>
+      <gh-input label="Password" type="password" required></gh-input>
     </div>
   </div>
 
   <div>
     <p class="demo-label">Card</p>
-    <gh-card label="손으로 그린 카드" elevated>
-      <p>이 카드의 테두리와 채움은 sketch-core가 그리고, 색·간격·반경은 토큰에서 옵니다.</p>
+    <gh-card label="Hand-drawn Card" elevated>
+      <p>This card's outline and fill are drawn by sketch-core, while its color, spacing, and radius come from the tokens.</p>
     </gh-card>
   </div>
 </div>

--- a/apps/website/src/components/ReactDemo.tsx
+++ b/apps/website/src/components/ReactDemo.tsx
@@ -14,11 +14,11 @@ export default function ReactDemo(): React.JSX.Element {
       <div>
         <p className="demo-label">Button</p>
         <div className="demo-row">
-          <Button variant="primary">기본</Button>
-          <Button variant="danger">위험</Button>
-          <Button variant="neutral">중립</Button>
+          <Button variant="primary">Default</Button>
+          <Button variant="danger">Danger</Button>
+          <Button variant="neutral">Neutral</Button>
           <Button variant="primary" disabled>
-            비활성
+            Disabled
           </Button>
         </div>
       </div>
@@ -27,20 +27,23 @@ export default function ReactDemo(): React.JSX.Element {
         <p className="demo-label">Input</p>
         <div className="demo-stack">
           <Input
-            label="이메일"
+            label="Email"
             placeholder="you@example.com"
             value={email}
             onChange={(event: ChangeEvent<HTMLInputElement>) => setEmail(event.target.value)}
           />
-          <Input label="비밀번호" type="password" error="8자 이상 입력해 주세요." />
+          <Input label="Password" type="password" error="Please enter at least 8 characters." />
         </div>
       </div>
 
       <div>
         <p className="demo-label">Card</p>
         <Card>
-          <h3>손으로 그린 카드</h3>
-          <p>이 카드의 테두리와 채움은 sketch-core가 그리고, 색·간격·반경은 토큰에서 옵니다.</p>
+          <h3>Hand-drawn Card</h3>
+          <p>
+            This card's outline and fill are drawn by sketch-core, while its color, spacing, and
+            radius come from the tokens.
+          </p>
         </Card>
       </div>
     </div>

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -17,7 +17,7 @@ const normalize = (path: string): string => path.replace(/\/+$/, '') || '/';
 const here = normalize(Astro.url.pathname);
 
 // A link is current on its own page and any nested route beneath it. The home
-// link ('/') matches only the home page, so 시작하기 is no longer wrongly active.
+// link ('/') matches only the home page, so Getting Started is no longer wrongly active.
 // `here` includes the configured base path, so compare against base-aware hrefs.
 const home = normalize(withBase('/'));
 function isCurrent(href: string): boolean {
@@ -30,7 +30,7 @@ function isCurrent(href: string): boolean {
 ---
 
 <!doctype html>
-<html lang="ko">
+<html lang="en">
   <head>
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
@@ -56,8 +56,8 @@ function isCurrent(href: string): boolean {
       <a class="brand" href={withBase('/')}>
         GHDS <small>GH Design System</small>
       </a>
-      <nav class="site-nav" aria-label="주요 메뉴">
-        <a href={withBase('/')} aria-current={isCurrent('/') ? 'page' : undefined}>홈</a>
+      <nav class="site-nav" aria-label="Main navigation">
+        <a href={withBase('/')} aria-current={isCurrent('/') ? 'page' : undefined}>Home</a>
         {
           NAV.map((item) => (
             <a href={withBase(item.href)} aria-current={isCurrent(item.href) ? 'page' : undefined}>
@@ -68,7 +68,7 @@ function isCurrent(href: string): boolean {
       </nav>
       <button id="theme-toggle" class="theme-toggle" type="button" aria-live="polite">
         <span data-theme-icon aria-hidden="true">🌗</span>
-        <span data-theme-label>테마</span>
+        <span data-theme-label>Theme</span>
       </button>
     </header>
 
@@ -77,7 +77,7 @@ function isCurrent(href: string): boolean {
     </main>
 
     <footer class="site-footer">
-      <p>GHDS — GH Design System · 모든 디자인 값은 <code>@ghds/tokens</code>에서 옵니다.</p>
+      <p>GHDS — GH Design System · Every design value comes from <code>@ghds/tokens</code>.</p>
     </footer>
 
     <script>
@@ -98,12 +98,12 @@ function isCurrent(href: string): boolean {
       function paint(): void {
         const current = effectiveTheme();
         if (label) {
-          label.textContent = current === 'dark' ? '라이트 모드' : '다크 모드';
+          label.textContent = current === 'dark' ? 'Light Mode' : 'Dark Mode';
         }
         if (icon) {
           icon.textContent = current === 'dark' ? '☀️' : '🌙';
         }
-        toggle?.setAttribute('aria-label', current === 'dark' ? '라이트 모드로 전환' : '다크 모드로 전환');
+        toggle?.setAttribute('aria-label', current === 'dark' ? 'Switch to light mode' : 'Switch to dark mode');
       }
 
       toggle?.addEventListener('click', () => {

--- a/apps/website/src/lib/nav.ts
+++ b/apps/website/src/lib/nav.ts
@@ -1,9 +1,7 @@
 /** KRDS-style information architecture for the GHDS documentation site. */
 export interface NavItem {
-  /** Korean section label (primary). */
+  /** Section label used in the nav and home page card grid. */
   readonly label: string;
-  /** English section label (secondary). */
-  readonly labelEn: string;
   /** Route path. */
   readonly href: string;
   /** One-line description used on the home page section grid. */
@@ -12,39 +10,34 @@ export interface NavItem {
 
 export const NAV: readonly NavItem[] = [
   {
-    label: '시작하기',
-    labelEn: 'Getting Started',
+    label: 'Getting Started',
     href: '/getting-started/',
-    summary: 'GHDS를 설치하고 첫 컴포넌트를 화면에 그려봅니다.',
+    summary: 'Install GHDS and render your first component on screen.',
   },
   {
-    label: '디자인 스타일',
-    labelEn: 'Design Style',
+    label: 'Design Style',
     href: '/design-style/',
-    summary: '색상·타이포·간격·반경·그림자 — @ghds/tokens에서 자동 생성한 디자인 토큰.',
+    summary:
+      'Color, typography, spacing, radius, and shadow — design tokens generated automatically from @ghds/tokens.',
   },
   {
-    label: '컴포넌트 가이드',
-    labelEn: 'Components',
+    label: 'Components',
     href: '/components/',
-    summary: 'React와 Lit 컴포넌트를 한 화면에서 나란히 라이브 렌더링합니다.',
+    summary: 'Live-render React and Lit components side by side on one screen.',
   },
   {
-    label: '패턴',
-    labelEn: 'Patterns',
+    label: 'Patterns',
     href: '/patterns/',
-    summary: '폼, 피드백 등 화면을 구성하는 재사용 가능한 조합 패턴.',
+    summary: 'Reusable composition patterns for forms, feedback, and more.',
   },
   {
-    label: '소개·접근성',
-    labelEn: 'About & Accessibility',
+    label: 'About & Accessibility',
     href: '/about/',
-    summary: '디자인 시스템의 철학과 WCAG 2.1 AA 접근성 약속.',
+    summary: "The design system's philosophy and its WCAG 2.1 AA accessibility commitment.",
   },
   {
-    label: '리소스',
-    labelEn: 'Resources',
+    label: 'Resources',
     href: '/resources/',
-    summary: '패키지, 저장소, 변경 이력 등 개발에 필요한 링크 모음.',
+    summary: 'A collection of links for packages, the repository, changelog, and more.',
   },
 ];

--- a/apps/website/src/pages/about.mdx
+++ b/apps/website/src/pages/about.mdx
@@ -1,25 +1,28 @@
 ---
 layout: ../layouts/MarkdownLayout.astro
-title: 소개·접근성
-description: 디자인 시스템의 철학과 WCAG 2.1 AA 접근성 약속.
+title: About & Accessibility
+description: The design system's philosophy and its WCAG 2.1 AA accessibility commitment.
 ---
 
-GHDS(GH Design System)는 손으로 그린(sketchy) 룩앤필을 유지하면서도 일관성과 접근성을
-양보하지 않는 크로스플랫폼 디자인 시스템입니다.
+GHDS (GH Design System) is a cross-platform design system that keeps its hand-drawn (sketchy)
+look and feel without compromising on consistency or accessibility.
 
-## 철학
+## Philosophy
 
-- **토큰이 단일 진실 공급원** — 모든 색·간격·타이포·반경·그림자는 `@ghds/tokens`에서 나옵니다.
-- **프레임워크 중립** — React, Lit 웹 컴포넌트, React Native가 동일한 토큰을 소비합니다.
-- **3계층 토큰** — `comp → sys → ref` 경계를 지켜 의미와 값을 분리합니다.
+- **Tokens are the single source of truth** — every color, spacing, typography, radius, and
+  shadow value comes from `@ghds/tokens`.
+- **Framework-neutral** — React, Lit web components, and React Native all consume the same
+  tokens.
+- **Three-tier tokens** — the `comp → sys → ref` boundary separates meaning from value.
 
-## 접근성 약속
+## Accessibility Commitment
 
-- 텍스트/배경 색상 쌍은 **WCAG 2.1 AA** 대비 최소치(일반 4.5:1, 큰 텍스트 3:1)를 충족하며,
-  이는 토큰 패키지에서 자동 검증됩니다.
-- 컴포넌트는 키보드 포커스, `aria-*` 속성, 의미 있는 레이블을 기본 제공합니다.
-- 다크 모드는 `[data-theme="dark"]` 토큰으로 동작하며, 사용자 시스템 설정도 존중합니다.
+- Text/background color pairings meet **WCAG 2.1 AA** contrast minimums (4.5:1 for normal text,
+  3:1 for large text), validated automatically in the tokens package.
+- Components ship with keyboard focus, `aria-*` attributes, and meaningful labels by default.
+- Dark mode works via the `[data-theme="dark"]` token, and also respects the user's system
+  preference.
 
-## 라이선스
+## License
 
 MIT.

--- a/apps/website/src/pages/components.astro
+++ b/apps/website/src/pages/components.astro
@@ -5,17 +5,18 @@ import BaseLayout from '../layouts/BaseLayout.astro';
 ---
 
 <BaseLayout
-  title="컴포넌트 가이드"
-  description="React(@ghds/react)와 Lit(@ghds/web-components) Button·Card·Input을 한 화면에서 나란히 라이브 렌더링합니다."
+  title="Components"
+  description="Live-renders React (@ghds/react) and Lit (@ghds/web-components) Button, Card, and Input side by side on one screen."
 >
   <section class="page-intro">
-    <span class="eyebrow">Components · 컴포넌트 가이드</span>
-    <h1>컴포넌트 가이드</h1>
+    <span class="eyebrow">Components</span>
+    <h1>Components</h1>
     <p>
-      동일한 <code>@ghds/tokens</code>를 소비하는 두 구현 — React 컴포넌트와 Lit 웹 컴포넌트 —
-      을 같은 화면에서 비교합니다. 색·간격·반경·타이포는 토큰에서, 손그림 외곽선은
-      <code>@ghds/sketch-core</code>에서 옵니다. 우측 상단 토글로 다크 모드를 켜면 양쪽이 동일하게
-      반응합니다.
+      Compare two implementations that consume the same <code>@ghds/tokens</code> — a React
+      component and a Lit web component — side by side on one screen. Color, spacing, radius, and
+      typography come from the tokens, and the hand-drawn outlines come from
+      <code>@ghds/sketch-core</code>. Toggle dark mode in the top-right corner and both respond
+      identically.
     </p>
   </section>
 
@@ -35,11 +36,11 @@ import BaseLayout from '../layouts/BaseLayout.astro';
   </section>
 
   <section class="section panel">
-    <h2>크로스 프레임워크, 단일 토큰</h2>
+    <h2>Cross-Framework, Single Token Source</h2>
     <p>
-      두 열은 서로 다른 런타임(React 가상 DOM vs. 네이티브 커스텀 엘리먼트)을 사용하지만
-      시각 결과는 동일합니다. 이것이 토큰을 단일 진실 공급원으로 두는 이유입니다 — 한 곳에서
-      값을 바꾸면 모든 프레임워크가 함께 바뀝니다.
+      The two columns use different runtimes (React's virtual DOM vs. native custom elements),
+      but the visual result is identical. This is why tokens are kept as the single source of
+      truth — change a value in one place, and every framework changes with it.
     </p>
   </section>
 </BaseLayout>

--- a/apps/website/src/pages/design-style.astro
+++ b/apps/website/src/pages/design-style.astro
@@ -13,21 +13,22 @@ const shadow = designStyle.shadow();
 ---
 
 <BaseLayout
-  title="디자인 스타일"
-  description="@ghds/tokens에서 자동 생성한 색상, 타이포그래피, 간격, 반경, 그림자 디자인 토큰."
+  title="Design Style"
+  description="Color, typography, spacing, radius, and shadow design tokens generated automatically from @ghds/tokens."
 >
   <section class="page-intro">
-    <span class="eyebrow">Design Style · 디자인 토큰</span>
-    <h1>디자인 스타일</h1>
+    <span class="eyebrow">Design Style</span>
+    <h1>Design Style</h1>
     <p>
-      이 페이지의 모든 값은 <code>@ghds/tokens</code> 빌드 산출물에서 직접 읽어 생성됩니다.
-      손으로 옮겨 적은 값은 하나도 없으며, 토큰이 바뀌면 이 페이지도 함께 갱신됩니다.
-      각 스와치는 생성된 CSS 변수(<code>var(--…)</code>)를 그대로 사용하므로 다크 모드도 즉시 반영됩니다.
+      Every value on this page is read directly from the <code>@ghds/tokens</code> build output.
+      Nothing here is hand-copied — when a token changes, this page updates with it. Each swatch
+      uses the generated CSS variable (<code>var(--…)</code>) directly, so dark mode is reflected
+      instantly too.
     </p>
   </section>
 
   <section class="section">
-    <h2>레퍼런스 팔레트 <code>ref.palette.*</code></h2>
+    <h2>Reference Palette <code>ref.palette.*</code></h2>
     {
       palette.map((family) => (
         <div class="section">
@@ -49,16 +50,16 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>시맨틱 색상 <code>sys.color.*</code></h2>
+    <h2>Semantic Colors <code>sys.color.*</code></h2>
     <table class="token-table">
-      <caption>역할(role) 기반 색상. 값이 다크 테마에서 달라지는 경우 함께 표기합니다.</caption>
+      <caption>Role-based colors. Values that differ in the dark theme are shown alongside.</caption>
       <thead>
         <tr>
-          <th scope="col">미리보기</th>
-          <th scope="col">토큰</th>
-          <th scope="col">CSS 변수</th>
-          <th scope="col">라이트</th>
-          <th scope="col">다크</th>
+          <th scope="col">Preview</th>
+          <th scope="col">Token</th>
+          <th scope="col">CSS Variable</th>
+          <th scope="col">Light</th>
+          <th scope="col">Dark</th>
         </tr>
       </thead>
       <tbody>
@@ -80,7 +81,7 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>타이포그래피 <code>sys.typography.*</code></h2>
+    <h2>Typography <code>sys.typography.*</code></h2>
     <div class="demo-stack">
       {
         typography.map((role) => (
@@ -91,7 +92,7 @@ const shadow = designStyle.shadow();
             <div
               style={`font-family: var(--sys-typography-${role.role}-fontFamily); font-size: var(--sys-typography-${role.role}-fontSize); line-height: var(--sys-typography-${role.role}-lineHeight); font-weight: var(--sys-typography-${role.role}-fontWeight);`}
             >
-              다람쥐 헌 쳇바퀴에 타고파 — The quick brown fox 0123
+              The quick brown fox jumps over the lazy dog — 0123
             </div>
           </div>
         ))
@@ -100,7 +101,7 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>간격 <code>sys.spacing.*</code></h2>
+    <h2>Spacing <code>sys.spacing.*</code></h2>
     <table class="token-table">
       <tbody>
         {
@@ -122,7 +123,7 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>모서리 반경 <code>sys.radius.*</code></h2>
+    <h2>Corner Radius <code>sys.radius.*</code></h2>
     <div class="demo-row">
       {
         radius.map((token) => (
@@ -138,7 +139,7 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>그림자 <code>sys.shadow.*</code></h2>
+    <h2>Shadow <code>sys.shadow.*</code></h2>
     <div class="demo-row" style="gap: var(--sys-spacing-lg);">
       {
         shadow.map((token) => (

--- a/apps/website/src/pages/getting-started.mdx
+++ b/apps/website/src/pages/getting-started.mdx
@@ -1,51 +1,53 @@
 ---
 layout: ../layouts/MarkdownLayout.astro
-title: 시작하기
-description: GHDS를 설치하고 첫 컴포넌트를 화면에 그려봅니다.
+title: Getting Started
+description: Install GHDS and render your first component on screen.
 ---
 
-GHDS는 pnpm 워크스페이스로 배포되는 모노레포입니다. 프레임워크에 맞는 패키지와 토큰을 함께 설치하세요.
+GHDS is a monorepo published as pnpm workspaces. Install the package for your framework along with
+the tokens.
 
-## 설치
+## Installation
 
 ```bash
-# React 앱
+# React app
 pnpm add @ghds/react @ghds/tokens
 
-# 프레임워크 무관 (Lit 웹 컴포넌트)
+# Framework-agnostic (Lit web components)
 pnpm add @ghds/web-components @ghds/tokens
 ```
 
-## 토큰 CSS 변수 불러오기
+## Import Token CSS Variables
 
-모든 컴포넌트는 `@ghds/tokens`의 CSS 변수에서 색·간격·반경 등을 읽습니다.
-앱 진입점에서 한 번만 불러오면 됩니다.
+Every component reads its color, spacing, radius, and other values from `@ghds/tokens`'s CSS
+variables. Import it once at your app's entry point.
 
 ```ts
 import '@ghds/tokens/css';
 ```
 
-## React에서 사용하기
+## Using it in React
 
 ```tsx
 import { Button } from '@ghds/react';
 
 export function Example() {
-  return <Button variant="primary">안녕하세요</Button>;
+  return <Button variant="primary">Hello</Button>;
 }
 ```
 
-## Lit 웹 컴포넌트로 사용하기
+## Using it as a Lit Web Component
 
 ```ts
 import '@ghds/web-components';
 ```
 
 ```html
-<gh-button variant="primary">안녕하세요</gh-button>
+<gh-button variant="primary">Hello</gh-button>
 ```
 
-## 다음 단계
+## Next Steps
 
-- [디자인 스타일](../design-style/) — 토큰으로 자동 생성된 색상·타이포·간격 갤러리
-- [컴포넌트 가이드](../components/) — React와 Lit을 나란히 비교하는 라이브 데모
+- [Design Style](../design-style/) — a gallery of color, typography, and spacing generated
+  automatically from tokens
+- [Components](../components/) — a live demo comparing React and Lit side by side

--- a/apps/website/src/pages/index.astro
+++ b/apps/website/src/pages/index.astro
@@ -5,31 +5,30 @@ import { withBase } from '../lib/withBase';
 ---
 
 <BaseLayout
-  title="홈"
-  description="GHDS는 손으로 그린(sketchy) 룩앤필의 크로스플랫폼 디자인 시스템입니다. 토큰을 단일 진실 공급원으로, React·Lit·React Native에 동일한 스타일을 제공합니다."
+  title="Home"
+  description="GHDS is a cross-platform design system with a hand-drawn (sketchy) look and feel. With tokens as the single source of truth, it delivers the same styling across React, Lit, and React Native."
 >
   <section class="section page-intro">
     <span class="eyebrow">GH Design System</span>
-    <h1>한 번의 토큰, 모든 프레임워크에서 같은 손그림.</h1>
+    <h1>One set of tokens. The same hand-drawn look, in every framework.</h1>
     <p>
-      GHDS는 <code>@ghds/tokens</code>를 단일 진실 공급원으로 삼아 React, Lit 웹 컴포넌트,
-      React Native에 동일한 hand-drawn 스타일을 제공하는 크로스플랫폼 디자인 시스템입니다.
-      아래 문서에서 토큰, 컴포넌트, 패턴을 둘러보세요.
+      GHDS is a cross-platform design system that uses <code>@ghds/tokens</code> as its single
+      source of truth to deliver the same hand-drawn style across React, Lit web components, and
+      React Native. Explore the tokens, components, and patterns in the docs below.
     </p>
     <p class="demo-row">
-      <a class="theme-toggle" href={withBase('/getting-started/')}>시작하기 →</a>
-      <a class="theme-toggle" href={withBase('/components/')}>컴포넌트 보기</a>
+      <a class="theme-toggle" href={withBase('/getting-started/')}>Get Started →</a>
+      <a class="theme-toggle" href={withBase('/components/')}>View Components</a>
     </p>
   </section>
 
   <section class="section">
-    <h2>둘러보기</h2>
+    <h2>Explore</h2>
     <div class="card-grid">
       {
         NAV.map((item) => (
           <a class="io-card" href={withBase(item.href)}>
             <h3>{item.label}</h3>
-            <span class="io-en">{item.labelEn}</span>
             <p>{item.summary}</p>
           </a>
         ))

--- a/apps/website/src/pages/patterns.mdx
+++ b/apps/website/src/pages/patterns.mdx
@@ -1,25 +1,27 @@
 ---
 layout: ../layouts/MarkdownLayout.astro
-title: 패턴
-description: 폼, 피드백 등 화면을 구성하는 재사용 가능한 조합 패턴.
+title: Patterns
+description: Reusable composition patterns for forms, feedback, and more.
 ---
 
-패턴은 여러 컴포넌트를 조합해 반복되는 사용자 흐름을 해결하는 방법을 안내합니다.
-아래 항목은 IA 골격으로, 깊이 있는 내용은 이후 채워집니다.
+Patterns show how to combine multiple components to solve recurring user flows. The items below
+are an IA skeleton — deeper content will be filled in later.
 
-## 폼 패턴
+## Form Patterns
 
-- 레이블·입력·도움말·오류 메시지의 배치와 간격 (모두 `sys.spacing.*` 사용)
-- 유효성 검사와 `aria-invalid` / `role="alert"` 처리
+- Placement and spacing of labels, inputs, helper text, and error messages (all using
+  `sys.spacing.*`)
+- Validation and `aria-invalid` / `role="alert"` handling
 
-## 피드백 패턴
+## Feedback Patterns
 
-- 성공·경고·위험 상태 색상 (`sys.color.bg.success` 등)
-- 토스트와 인라인 알림의 사용 시점
+- Success/warning/danger state colors (`sys.color.bg.success`, etc.)
+- When to use toasts vs. inline alerts
 
-## 레이아웃 패턴
+## Layout Patterns
 
-- 카드 그리드와 반응형 트랙
-- 헤더·본문·푸터 셸 구성
+- Card grids and responsive tracks
+- Header/body/footer shell composition
 
-> 이 페이지는 정보 구조(IA) 골격 스텁입니다. 라우팅과 내비게이션은 실제로 동작합니다.
+> This page is an information architecture (IA) skeleton stub. Routing and navigation are fully
+> functional.

--- a/apps/website/src/pages/resources.mdx
+++ b/apps/website/src/pages/resources.mdx
@@ -1,37 +1,39 @@
 ---
 layout: ../layouts/MarkdownLayout.astro
-title: 리소스
-description: 패키지, 저장소, 변경 이력 등 개발에 필요한 링크 모음.
+title: Resources
+description: A collection of links for packages, the repository, changelog, and more.
 ---
 
-GHDS를 사용하고 기여하는 데 필요한 자료를 모았습니다.
+A collection of resources for using and contributing to GHDS.
 
-## 패키지
+## Packages
 
-- `@ghds/tokens` — 디자인 토큰 (단일 진실 공급원)
-- `@ghds/react` — React 컴포넌트 라이브러리
-- `@ghds/web-components` — Lit 기반 프레임워크 무관 웹 컴포넌트
-- `@ghds/react-native` — React Native 컴포넌트 라이브러리
+- `@ghds/tokens` — design tokens (single source of truth)
+- `@ghds/react` — React component library
+- `@ghds/web-components` — Lit-based framework-agnostic web components
+- `@ghds/react-native` — React Native component library
 
-## 저장소
+## Repository
 
-- [GitHub 저장소](https://github.com/GyeongHoKim/gyeongho-design-system) — 소스 코드, 이슈, 변경 이력
+- [GitHub Repository](https://github.com/GyeongHoKim/gyeongho-design-system) — source code, issues,
+  changelog
 
-## Storybook (로컬 실행)
+## Storybook (local)
 
-배포된 Storybook은 아직 없습니다. 저장소를 클론한 뒤 아래 명령으로 로컬에서 각 카탈로그를 띄울 수 있습니다.
+There's no deployed Storybook yet. Clone the repository and use the commands below to run each
+catalog locally.
 
 ```bash
-# React 컴포넌트 카탈로그 → http://localhost:6006
+# React component catalog → http://localhost:6006
 pnpm --filter storybook-react dev
 
-# 웹 컴포넌트(Lit) 카탈로그 → http://localhost:6007
+# Web components (Lit) catalog → http://localhost:6007
 pnpm --filter @ghds/storybook-web-components dev
 ```
 
-## 기여
+## Contributing
 
-- 변경 사항은 Changesets로 버전을 관리합니다 (`pnpm changeset`).
-- 모든 변경은 루트 `AGENTS.md`의 **Code Quality Gate**를 통과해야 합니다.
+- Changes are versioned with Changesets (`pnpm changeset`).
+- Every change must pass the **Code Quality Gate** in the root `AGENTS.md`.
 
-> 이 페이지는 IA 골격 스텁입니다. 배포된 Storybook URL이 생기면 이곳에 추가됩니다.
+> This page is an IA skeleton stub. A deployed Storybook URL will be added here once one exists.


### PR DESCRIPTION
## Summary
- `apps/website` was written entirely in Korean, but the promotional site is supposed to be English-first (GHD-43, Urgent).
- Translates all page content, nav labels, layout chrome (nav/footer/theme toggle), and demo components (LitDemo/ReactDemo) to English.
- Sets `<html lang="en">`.
- Drops the now-redundant `labelEn` field from `nav.ts` — its English text becomes the primary `label`; the home page's bilingual card tag is removed accordingly.
- English-only per decision on GHD-43 — no i18n toggle/locale routing added (that would be a separate follow-up issue if ever wanted).

## Test plan
- [x] `grep` for Hangul across `apps/website/src` and the built `dist/` output — zero matches
- [x] `grep` for `labelEn` — zero matches (fully removed)
- [x] `pnpm --filter website lint` — passes
- [x] `pnpm --filter website test` — 5/5 passing
- [x] `pnpm --filter website build` — all 7 pages build cleanly
- [x] Verified rendered HTML via dev server (`curl` against all 7 routes): correct `lang="en"`, nav/footer/theme-toggle text, home card grid renders without the removed `io-en` span, "Next Steps" links match nav labels exactly, Lit demo column shows English labels server-side; React demo (`client:only`) wording verified via source review to match Lit's exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Converted the website’s core pages and component demos from Korean to English for a more consistent browsing experience.
  * Updated navigation labels, page titles, descriptions, and section copy across onboarding, design tokens, patterns, resources, and about pages.
  * Simplified the home page’s card display to show a single, cleaner label per item.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->