### PR TITLE
feat(tokens): breakpoint/grid/z-index/opacity tokens + Foundations page

### DIFF
--- a/apps/website/src/lib/nav.ts
+++ b/apps/website/src/lib/nav.ts
@@ -21,6 +21,12 @@ export const NAV: readonly NavItem[] = [
       'Color, typography, spacing, radius, and shadow — design tokens generated automatically from @ghds/tokens.',
   },
   {
+    label: 'Foundations',
+    href: '/foundations/',
+    summary:
+      'Layout & grid, icons, motion, elevation, and z-index layering — the structural and interaction primitives behind every component.',
+  },
+  {
     label: 'Components',
     href: '/components/',
     summary: 'Live-render React and Lit components side by side on one screen.',

--- a/apps/website/src/lib/tokens.ts
+++ b/apps/website/src/lib/tokens.ts
@@ -150,3 +150,14 @@ export const designStyle = {
   radius: (): FlatToken[] => section('sys.radius'),
   shadow: (): FlatToken[] => section('sys.shadow'),
 };
+
+/** Convenience accessors for the Foundations page sections. */
+export const foundations = {
+  breakpoint: (): FlatToken[] => section('sys.breakpoint'),
+  grid: (): FlatToken[] => section('sys.grid'),
+  container: (): FlatToken[] => section('sys.container'),
+  zIndex: (): FlatToken[] => section('sys.zIndex'),
+  opacity: (): FlatToken[] => section('sys.opacity'),
+  duration: (): FlatToken[] => section('sys.animation.duration'),
+  easing: (): FlatToken[] => section('sys.animation.easing'),
+};

--- a/apps/website/src/pages/design-style.astro
+++ b/apps/website/src/pages/design-style.astro
@@ -139,7 +139,7 @@ const shadow = designStyle.shadow();
   </section>
 
   <section class="section">
-    <h2>Shadow <code>sys.shadow.*</code></h2>
+    <h2 id="shadow">Shadow <code>sys.shadow.*</code></h2>
     <div class="demo-row" style="gap: var(--sys-spacing-lg);">
       {
         shadow.map((token) => (

--- a/apps/website/src/pages/foundations.astro
+++ b/apps/website/src/pages/foundations.astro
@@ -1,0 +1,211 @@
+---
+import BaseLayout from '../layouts/BaseLayout.astro';
+import { foundations } from '../lib/tokens';
+import { withBase } from '../lib/withBase';
+
+// All data below is DERIVED from @ghds/tokens at build time — nothing is
+// hand-copied. Change a token and this page regenerates.
+const breakpoint = foundations.breakpoint();
+const grid = foundations.grid();
+const container = foundations.container();
+const zIndex = foundations.zIndex();
+const opacity = foundations.opacity();
+const duration = foundations.duration();
+const easing = foundations.easing();
+
+/** Build a `key -> token` lookup from a `FlatToken[]`, stripping a shared path prefix. */
+function byKey<T extends { path: string; value: unknown }>(tokens: T[], prefix: string) {
+  return new Map(tokens.map((t) => [t.path.replace(prefix, ''), t]));
+}
+
+const gridColumnsByKey = byKey(
+  grid.filter((t) => t.path.startsWith('sys.grid.columns.')),
+  'sys.grid.columns.',
+);
+const gridGutterByKey = byKey(
+  grid.filter((t) => t.path.startsWith('sys.grid.gutter.')),
+  'sys.grid.gutter.',
+);
+const containerMaxWidthByKey = byKey(container, 'sys.container.maxWidth.');
+const durationByKey = byKey(duration, 'sys.animation.duration.');
+
+const durationSummary = duration
+  .map((t) => `${t.path.replace('sys.animation.duration.', '')} = ${t.value}`)
+  .join(', ');
+const easingSummary = easing.map((t) => t.path.replace('sys.animation.easing.', '')).join(', ');
+const opacitySummary = opacity
+  .map((t) => `${t.path.replace('sys.opacity.', '')} = ${t.value}`)
+  .join(', ');
+
+const zIndexNotes: Record<string, string> = {
+  base: 'Default stacking context. Most in-flow content never needs to set z-index at all.',
+  dropdown: 'Select menus, comboboxes, and other inline popovers anchored to a trigger.',
+  sticky: 'Elements pinned within the normal document flow, e.g. the site header.',
+  overlay: 'Full-viewport scrims that sit behind a modal or drawer.',
+  modal: 'Modal and dialog surfaces themselves, above their scrim.',
+  toast: 'Toast/snackbar notifications, above modals so they stay visible.',
+  tooltip: 'Tooltips — always on top, since they must never be obscured by anything else.',
+};
+---
+
+<BaseLayout
+  title="Foundations"
+  description="Layout & grid, icons, motion, elevation, and z-index layering — the structural and interaction primitives behind every component."
+>
+  <section class="page-intro">
+    <span class="eyebrow">Foundations</span>
+    <h1>Foundations</h1>
+    <p>
+      The structural and interaction primitives every component builds on: responsive layout,
+      icon sizing, motion, elevation, and stacking order. Like <a href={withBase('/design-style/')}>Design
+      Style</a>, every value below is read directly from the <code>@ghds/tokens</code> build
+      output.
+    </p>
+  </section>
+
+  <section class="section">
+    <h2>Layout &amp; Grid <code>sys.breakpoint.*</code> <code>sys.grid.*</code> <code>sys.container.*</code></h2>
+    <p>
+      Breakpoints are mobile-first: each value is a <code>min-width</code> for
+      <code>@media</code> queries, so mobile styles are the default and larger breakpoints layer
+      on top. Grid column counts and container max-widths scale together — more columns and a
+      wider container as the viewport grows.
+    </p>
+    <table class="token-table">
+      <thead>
+        <tr>
+          <th scope="col">Breakpoint</th>
+          <th scope="col"><code>sys.breakpoint.*</code></th>
+          <th scope="col">Columns</th>
+          <th scope="col">Container max-width</th>
+          <th scope="col">Gutter</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          breakpoint.map((bp) => {
+            const key = bp.path.replace('sys.breakpoint.', '');
+            const columns = gridColumnsByKey.get(key);
+            const maxWidth = containerMaxWidthByKey.get(key);
+            const gutter = gridGutterByKey.get(key);
+            return (
+              <tr>
+                <td>{key}</td>
+                <td><code set:text={bp.value} /></td>
+                <td>{columns ? columns.value : '—'}</td>
+                <td>{maxWidth ? <code set:text={maxWidth.value} /> : <em>fluid (100%)</em>}</td>
+                <td>{gutter ? <code set:text={gutter.value} /> : '—'}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    </table>
+    <p>
+      <strong>Stack/Grid layout primitive:</strong> no dedicated <code>Stack</code>/<code>Grid</code>
+      component exists yet in any of the three platform packages. Until one ships (recommended for
+      a future component milestone), consume these tokens directly: on the web,
+      <code>@media (min-width: var(--sys-breakpoint-tablet))</code>; in React Native, which has no
+      native media queries, compare <code>useWindowDimensions()</code> against the same token
+      values read from <code>@ghds/tokens</code>.
+    </p>
+  </section>
+
+  <section class="section">
+    <h2>Icons <code>sys.icon.size.*</code></h2>
+    <p>
+      Icon sizing follows the <code>sys.icon.size.sm/md/lg</code> scale (see the <code>Icon</code>
+      component across all three platforms). A full icon catalog page doesn't exist yet — this
+      section will link to one once it's built.
+    </p>
+  </section>
+
+  <section class="section">
+    <h2>Motion <code>sys.animation.duration.*</code> <code>sys.animation.easing.*</code></h2>
+    <p>Named transition patterns and which duration/easing pair backs each one:</p>
+    <table class="token-table">
+      <thead>
+        <tr>
+          <th scope="col">Pattern</th>
+          <th scope="col">Duration</th>
+          <th scope="col">Easing</th>
+          <th scope="col">When to use</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>Enter</td>
+          <td><code set:text={durationByKey.get('normal')?.value} /></td>
+          <td><code>sys.animation.easing.enter</code></td>
+          <td>An element appearing — modal open, dropdown open, toast in. Decelerates into place so arrival feels responsive, not abrupt.</td>
+        </tr>
+        <tr>
+          <td>Exit</td>
+          <td><code set:text={durationByKey.get('fast')?.value} /></td>
+          <td><code>sys.animation.easing.exit</code></td>
+          <td>An element disappearing — modal close, dropdown close, toast out. Faster than enter and accelerates away, so it never blocks the next action.</td>
+        </tr>
+        <tr>
+          <td>Emphasis</td>
+          <td><code set:text={durationByKey.get('slow')?.value} /></td>
+          <td><code>sys.animation.easing.emphasized</code></td>
+          <td>Drawing attention without appearing/disappearing — a validation-error nudge, a pulse. Product judgment call on exact duration.</td>
+        </tr>
+      </tbody>
+    </table>
+    <p>
+      <strong>Raw values</strong> — <code>sys.animation.duration.*</code>: <code set:text={durationSummary} />.
+      <code>sys.animation.easing.*</code>: <code set:text={easingSummary} />.
+    </p>
+    <p>
+      <strong>Accessibility:</strong> when <code>prefers-reduced-motion</code> matches, skip the
+      transition entirely or substitute an instant/opacity-only crossfade at
+      <code>ref.duration.instant</code> (<code>0ms</code>). This is an implementation-layer concern
+      for each component package, not a separate token.
+    </p>
+  </section>
+
+  <section class="section">
+    <h2>Elevation <code>sys.shadow.*</code></h2>
+    <p>
+      Elevation is covered on the <a href={withBase('/design-style/#shadow')}>Design Style</a> page.
+      Reach for a higher shadow tier as an element's stacking layer rises (dropdown → modal →
+      toast); <code>sys.sketch.elevation</code> drives the same idea for the hand-drawn drop-shadow
+      on cards and raised surfaces.
+    </p>
+  </section>
+
+  <section class="section">
+    <h2>Z-index / Layering <code>sys.zIndex.*</code></h2>
+    <table class="token-table">
+      <thead>
+        <tr>
+          <th scope="col">Layer</th>
+          <th scope="col">Value</th>
+          <th scope="col">When to use</th>
+        </tr>
+      </thead>
+      <tbody>
+        {
+          zIndex.map((token) => {
+            const key = token.path.replace('sys.zIndex.', '');
+            return (
+              <tr>
+                <td><code set:text={key} /></td>
+                <td><code set:text={token.value} /></td>
+                <td>{zIndexNotes[key]}</td>
+              </tr>
+            );
+          })
+        }
+      </tbody>
+    </table>
+    <p>
+      Worked example: this site's <code>.site-header</code> is <code>position: sticky</code>, so
+      it uses <code>var(--sys-zIndex-sticky)</code> rather than a hardcoded number.
+    </p>
+    <p>
+      <strong>Opacity</strong> <code>sys.opacity.*</code>: <code set:text={opacitySummary} />.
+    </p>
+  </section>
+</BaseLayout>

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -61,6 +61,9 @@ h3 {
   font-family: var(--sys-typography-heading-fontFamily);
   line-height: var(--sys-typography-heading-lineHeight);
   margin: 0 0 var(--sys-spacing-md);
+  /* Clears the sticky `.site-header` when a heading is the target of an
+   * in-page anchor link (e.g. #shadow), so it isn't scrolled under it. */
+  scroll-margin-top: 6rem;
 }
 
 h1 {
@@ -88,7 +91,7 @@ code {
 .site-header {
   position: sticky;
   top: 0;
-  z-index: 10;
+  z-index: var(--sys-zIndex-sticky);
   display: flex;
   align-items: center;
   justify-content: space-between;

--- a/packages/tokens/src/ref/effect.json
+++ b/packages/tokens/src/ref/effect.json
@@ -57,6 +57,24 @@
         "flat": { "$value": 0 },
         "raised": { "$value": 4 }
       }
+    },
+    "zIndex": {
+      "$type": "number",
+      "$description": "Tier 1 stacking layers. Spaced by 100 to leave room for future insertions.",
+      "base": { "$value": 0 },
+      "dropdown": { "$value": 1000 },
+      "sticky": { "$value": 1100 },
+      "overlay": { "$value": 1200 },
+      "modal": { "$value": 1300 },
+      "toast": { "$value": 1400 },
+      "tooltip": { "$value": 1500 }
+    },
+    "opacity": {
+      "$type": "number",
+      "$description": "Tier 1 opacity scale. Unitless 0-1, matching the ref.sketch precedent for unitless number scales.",
+      "disabled": { "$value": 0.4 },
+      "hover": { "$value": 0.08 },
+      "scrim": { "$value": 0.5 }
     }
   }
 }

--- a/packages/tokens/src/ref/layout.json
+++ b/packages/tokens/src/ref/layout.json
@@ -1,0 +1,31 @@
+{
+  "ref": {
+    "breakpoint": {
+      "$type": "dimension",
+      "$description": "Tier 1 responsive breakpoints. Mobile-first: each is a min-width for @media queries.",
+      "mobile": { "$value": "0px" },
+      "tablet": { "$value": "768px" },
+      "desktop": { "$value": "1024px" },
+      "wide": { "$value": "1440px" }
+    },
+    "container": {
+      "maxWidth": {
+        "$type": "dimension",
+        "$description": "Tier 1 content max-widths per breakpoint. Mobile is intentionally fluid (100%) and has no entry.",
+        "tablet": { "$value": "720px" },
+        "desktop": { "$value": "960px" },
+        "wide": { "$value": "1280px" }
+      }
+    },
+    "grid": {
+      "columns": {
+        "$type": "number",
+        "$description": "Tier 1 grid column counts per breakpoint.",
+        "mobile": { "$value": 4 },
+        "tablet": { "$value": 8 },
+        "desktop": { "$value": 12 },
+        "wide": { "$value": 12 }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/sys/_shared.json
+++ b/packages/tokens/src/sys/_shared.json
@@ -115,6 +115,59 @@
         "md": { "$value": "{ref.iconSize.md}" },
         "lg": { "$value": "{ref.iconSize.lg}" }
       }
+    },
+    "breakpoint": {
+      "$type": "dimension",
+      "$description": "Tier 2 semantic breakpoints. Theme-invariant.",
+      "mobile": { "$value": "{ref.breakpoint.mobile}" },
+      "tablet": { "$value": "{ref.breakpoint.tablet}" },
+      "desktop": { "$value": "{ref.breakpoint.desktop}" },
+      "wide": { "$value": "{ref.breakpoint.wide}" }
+    },
+    "container": {
+      "maxWidth": {
+        "$type": "dimension",
+        "$description": "Tier 2 semantic container max-widths. Theme-invariant.",
+        "tablet": { "$value": "{ref.container.maxWidth.tablet}" },
+        "desktop": { "$value": "{ref.container.maxWidth.desktop}" },
+        "wide": { "$value": "{ref.container.maxWidth.wide}" }
+      }
+    },
+    "grid": {
+      "columns": {
+        "$type": "number",
+        "$description": "Tier 2 semantic grid column counts. Theme-invariant.",
+        "mobile": { "$value": "{ref.grid.columns.mobile}" },
+        "tablet": { "$value": "{ref.grid.columns.tablet}" },
+        "desktop": { "$value": "{ref.grid.columns.desktop}" },
+        "wide": { "$value": "{ref.grid.columns.wide}" }
+      },
+      "gutter": {
+        "$type": "dimension",
+        "$description": "Tier 2 grid gutters. Reuses the spacing scale directly (no dedicated ref.grid.gutter) to avoid a redundant parallel scale.",
+        "mobile": { "$value": "{ref.spacing.4}" },
+        "tablet": { "$value": "{ref.spacing.6}" },
+        "desktop": { "$value": "{ref.spacing.6}" },
+        "wide": { "$value": "{ref.spacing.8}" }
+      }
+    },
+    "zIndex": {
+      "$type": "number",
+      "$description": "Tier 2 semantic stacking layers. Theme-invariant. Consumed by future overlay-style components (Modal, Toast, Tooltip, Menu/Dropdown — see M11).",
+      "base": { "$value": "{ref.zIndex.base}" },
+      "dropdown": { "$value": "{ref.zIndex.dropdown}" },
+      "sticky": { "$value": "{ref.zIndex.sticky}" },
+      "overlay": { "$value": "{ref.zIndex.overlay}" },
+      "modal": { "$value": "{ref.zIndex.modal}" },
+      "toast": { "$value": "{ref.zIndex.toast}" },
+      "tooltip": { "$value": "{ref.zIndex.tooltip}" }
+    },
+    "opacity": {
+      "$type": "number",
+      "$description": "Tier 2 semantic opacity roles. Theme-invariant.",
+      "disabled": { "$value": "{ref.opacity.disabled}" },
+      "hover": { "$value": "{ref.opacity.hover}" },
+      "scrim": { "$value": "{ref.opacity.scrim}" }
     }
   }
 }


### PR DESCRIPTION
## Summary
- Adds `ref`/`sys` tier tokens for responsive breakpoints (mobile/tablet/desktop/wide), grid columns + container max-widths, a z-index stacking scale (base→tooltip), and an opacity scale (disabled/hover/scrim) — closes GHD-25 and GHD-26.
- Adds a new `/foundations/` page consolidating Layout & Grid, Icons, Motion, Elevation, and Z-index/Layering guidance, all with live token tables read from the built `@ghds/tokens` output — closes GHD-27.
- Fixes a pre-existing hardcoded `z-index: 10` on the sticky site header to consume the new `sys.zIndex.sticky` token.
- Scope note: GHD-25 also asked to "review" (검토) a cross-platform Stack/Grid layout primitive. Since the issue explicitly used softer language than component-build issues, and no Stack/Grid scaffolding exists in any of the 3 platform packages, this PR ships the breakpoint/grid tokens as the reviewed contract plus an in-page recommendation to build the primitive in a future milestone, rather than a new 3-platform component.

## Test plan
- [x] `pnpm test --filter @ghds/tokens` passes (90 tests, new token categories auto-covered by the glob-driven validation suite)
- [x] `pnpm build --filter @ghds/tokens` regenerates `dist/` with the new CSS vars (`--sys-breakpoint-*`, `--sys-grid-*`, `--sys-container-*`, `--sys-zIndex-*`, `--sys-opacity-*`)
- [x] `pnpm --filter @ghds/website lint` and `build` pass; `/foundations/index.html` generated with all 3 live tables rendering resolved values
- [x] Verified the sticky header's computed z-index reads `1100` via the new token, not the old hardcoded `10`
- [x] Verified all cross-page/anchor links resolve under the GitHub Pages base path
- [x] `pnpm --filter @ghds/react test` (26 tests) still passes, confirming `SketchSurface`'s unrelated local `zIndex: -1` (GHD-44 regression suite) is untouched
- [x] Reviewed via automated code-review workflow (high effort); found and fixed 3 issues: an Astro-compiler artifact where dynamic expressions as the sole child of `<code>` inside table cells produced malformed nested markup (worked around with `set:text`), a sticky-header/anchor-scroll overlap (added `scroll-margin-top`), and repeated `.find()` lookups replaced with `Map`-based lookups

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a new “Foundations” section to the site navigation and a dedicated page covering layout, grid, icons, motion, elevation, z-index, and opacity guidance.
  * Expanded the design system content with responsive breakpoints, container widths, grid columns, stacking layers, and opacity values.
* **Bug Fixes**
  * Improved in-page heading scrolling so anchored sections are no longer hidden behind the sticky header.
  * Updated header layering to use the design system’s stacking values.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->