### PR TITLE
feat(website): component documentation standard + accessibility guide

### DIFF
--- a/apps/website/src/components/DoDont.astro
+++ b/apps/website/src/components/DoDont.astro
@@ -5,18 +5,23 @@ interface Props {
 }
 
 const { do: doItems, dont: dontItems } = Astro.props;
+
+// Unique per render so multiple <DoDont> instances on one page don't collide.
+const uid = crypto.randomUUID();
+const doLabelId = `do-dont-do-${uid}`;
+const dontLabelId = `do-dont-dont-${uid}`;
 ---
 
 <div class="do-dont">
   <div>
-    <p class="demo-label">Do</p>
-    <ul>
+    <p class="demo-label" id={doLabelId}>Do</p>
+    <ul aria-labelledby={doLabelId}>
       {doItems.map((item) => <li>{item}</li>)}
     </ul>
   </div>
   <div>
-    <p class="demo-label">Don't</p>
-    <ul>
+    <p class="demo-label" id={dontLabelId}>Don't</p>
+    <ul aria-labelledby={dontLabelId}>
       {dontItems.map((item) => <li>{item}</li>)}
     </ul>
   </div>

--- a/apps/website/src/components/DoDont.astro
+++ b/apps/website/src/components/DoDont.astro
@@ -1,0 +1,23 @@
+---
+interface Props {
+  do: string[];
+  dont: string[];
+}
+
+const { do: doItems, dont: dontItems } = Astro.props;
+---
+
+<div class="do-dont">
+  <div>
+    <p class="demo-label">Do</p>
+    <ul>
+      {doItems.map((item) => <li>{item}</li>)}
+    </ul>
+  </div>
+  <div>
+    <p class="demo-label">Don't</p>
+    <ul>
+      {dontItems.map((item) => <li>{item}</li>)}
+    </ul>
+  </div>
+</div>

--- a/apps/website/src/components/KeyboardTable.astro
+++ b/apps/website/src/components/KeyboardTable.astro
@@ -1,0 +1,34 @@
+---
+/** Reused by each component page's Accessibility section and the standalone Accessibility Guide. */
+interface KeyRow {
+  keys: string;
+  action: string;
+}
+
+interface Props {
+  rows: KeyRow[];
+}
+
+const { rows } = Astro.props;
+---
+
+<table class="token-table">
+  <thead>
+    <tr>
+      <th scope="col">Key</th>
+      <th scope="col">Action</th>
+    </tr>
+  </thead>
+  <tbody>
+    {
+      rows.map((row) => (
+        <tr>
+          <td>
+            <code>{row.keys}</code>
+          </td>
+          <td>{row.action}</td>
+        </tr>
+      ))
+    }
+  </tbody>
+</table>

--- a/apps/website/src/components/PropsTable.astro
+++ b/apps/website/src/components/PropsTable.astro
@@ -1,0 +1,59 @@
+---
+/**
+ * Renders one props table per platform. Cross-platform prop names genuinely
+ * diverge (see GHD-28/30) — a single merged table would misrepresent them, so
+ * each platform group gets its own table rather than one shared column set.
+ */
+interface PropRow {
+  name: string;
+  type: string;
+  default?: string;
+  description: string;
+}
+
+interface PlatformGroup {
+  platform: string;
+  packageName: string;
+  rows: PropRow[];
+}
+
+interface Props {
+  groups: PlatformGroup[];
+}
+
+const { groups } = Astro.props;
+---
+
+{
+  groups.map((group) => (
+    <div class="props-group">
+      <h3>
+        {group.platform} <code>{group.packageName}</code>
+      </h3>
+      <table class="token-table">
+        <thead>
+          <tr>
+            <th scope="col">Prop</th>
+            <th scope="col">Type</th>
+            <th scope="col">Default</th>
+            <th scope="col">Description</th>
+          </tr>
+        </thead>
+        <tbody>
+          {group.rows.map((row) => (
+            <tr>
+              <td>
+                <code>{row.name}</code>
+              </td>
+              <td>
+                <code>{row.type}</code>
+              </td>
+              <td>{row.default !== undefined ? <code>{row.default}</code> : '—'}</td>
+              <td>{row.description}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  ))
+}

--- a/apps/website/src/components/StateList.astro
+++ b/apps/website/src/components/StateList.astro
@@ -1,0 +1,40 @@
+---
+/**
+ * Renders a component's variant/state matrix as an explicit table, including
+ * states the component does NOT implement — an absent state renders as a
+ * "Not implemented" row instead of being silently omitted, so a retrofit never
+ * quietly invents behavior a component doesn't actually have.
+ */
+interface StateRow {
+  name: string;
+  present: boolean;
+  note?: string;
+}
+
+interface Props {
+  states: StateRow[];
+}
+
+const { states } = Astro.props;
+---
+
+<table class="token-table">
+  <thead>
+    <tr>
+      <th scope="col">State</th>
+      <th scope="col">Status</th>
+      <th scope="col">Notes</th>
+    </tr>
+  </thead>
+  <tbody>
+    {
+      states.map((state) => (
+        <tr>
+          <td>{state.name}</td>
+          <td>{state.present ? 'Implemented' : 'Not implemented'}</td>
+          <td>{state.note ?? '—'}</td>
+        </tr>
+      ))
+    }
+  </tbody>
+</table>

--- a/apps/website/src/components/demos/ButtonDemo.astro
+++ b/apps/website/src/components/demos/ButtonDemo.astro
@@ -1,0 +1,16 @@
+---
+// Live demo of the `<gh-button>` web component. Registered as a client-side
+// island: the module script below imports the package, whose `@customElement`
+// side-effect defines <gh-button>.
+---
+
+<div class="demo-row">
+  <gh-button variant="primary">Primary</gh-button>
+  <gh-button variant="danger">Delete</gh-button>
+  <gh-button variant="neutral">Cancel</gh-button>
+  <gh-button variant="primary" disabled>Disabled</gh-button>
+</div>
+
+<script>
+  import '@ghds/web-components';
+</script>

--- a/apps/website/src/components/demos/ButtonDemo.tsx
+++ b/apps/website/src/components/demos/ButtonDemo.tsx
@@ -1,0 +1,15 @@
+import { Button } from '@ghds/react';
+
+/** Live demo of Button's real variant/state matrix, rendered as an Astro island. */
+export default function ButtonDemo(): React.JSX.Element {
+  return (
+    <div className="demo-row">
+      <Button variant="primary">Primary</Button>
+      <Button variant="danger">Delete</Button>
+      <Button variant="neutral">Cancel</Button>
+      <Button variant="primary" disabled>
+        Disabled
+      </Button>
+    </div>
+  );
+}

--- a/apps/website/src/components/demos/CardDemo.astro
+++ b/apps/website/src/components/demos/CardDemo.astro
@@ -1,0 +1,17 @@
+---
+// Live demo of `<gh-card>`. Uses `elevated` + `label`, not React's `fill` —
+// gh-card has no `fill` prop, matching its real API (see components/card.mdx).
+---
+
+<div class="demo-stack">
+  <gh-card label="Flat">
+    <p>Default sketch outline, no elevation.</p>
+  </gh-card>
+  <gh-card label="Elevated" elevated>
+    <p>Drop-shadow sketch outline suggests elevation.</p>
+  </gh-card>
+</div>
+
+<script>
+  import '@ghds/web-components';
+</script>

--- a/apps/website/src/components/demos/CardDemo.tsx
+++ b/apps/website/src/components/demos/CardDemo.tsx
@@ -1,0 +1,22 @@
+import { Card } from '@ghds/react';
+
+/**
+ * Live demo of Card's `fill` prop — React's variant. Note this is intentionally
+ * NOT the same prop as the Web Components/React Native demo below
+ * (`elevated`), since React's Card has no `elevated` prop and WC/RN have no
+ * `fill` prop — this is a real cross-platform API difference, not an omission.
+ */
+export default function CardDemo(): React.JSX.Element {
+  return (
+    <div className="demo-stack">
+      <Card fill="solid">
+        <h3>Solid</h3>
+        <p>Default hand-cut paper fill.</p>
+      </Card>
+      <Card fill="hachure">
+        <h3>Hachure</h3>
+        <p>Sketched, translucent fill.</p>
+      </Card>
+    </div>
+  );
+}

--- a/apps/website/src/components/demos/InputDemo.astro
+++ b/apps/website/src/components/demos/InputDemo.astro
@@ -1,0 +1,14 @@
+---
+// Live demo of `<gh-input>`. Shows `required` (its native constraint-validation
+// prop) instead of an error state — gh-input has no error/invalid prop today.
+---
+
+<div class="demo-stack">
+  <gh-input label="Email" placeholder="you@example.com" type="email"></gh-input>
+  <gh-input label="Username" required></gh-input>
+  <gh-input label="Disabled" disabled value="Can't edit this"></gh-input>
+</div>
+
+<script>
+  import '@ghds/web-components';
+</script>

--- a/apps/website/src/components/demos/InputDemo.tsx
+++ b/apps/website/src/components/demos/InputDemo.tsx
@@ -1,0 +1,24 @@
+import { Input } from '@ghds/react';
+import { type ChangeEvent, useState } from 'react';
+
+/**
+ * Live demo of Input's React variant, including its `error` state — React is
+ * currently the only platform with an error/invalid state (see the WC demo
+ * below, which intentionally has no error example).
+ */
+export default function InputDemo(): React.JSX.Element {
+  const [email, setEmail] = useState('');
+
+  return (
+    <div className="demo-stack">
+      <Input
+        label="Email"
+        placeholder="you@example.com"
+        value={email}
+        onChange={(event: ChangeEvent<HTMLInputElement>) => setEmail(event.target.value)}
+      />
+      <Input label="Password" type="password" error="Please enter at least 8 characters." />
+      <Input label="Disabled" disabled value="Can't edit this" onChange={() => {}} />
+    </div>
+  );
+}

--- a/apps/website/src/pages/about.mdx
+++ b/apps/website/src/pages/about.mdx
@@ -84,6 +84,9 @@ reference `ref` directly.
 - Dark mode works via the `[data-theme="dark"]` token, and also respects the user's system
   preference.
 
+See the <a href={withBase('/accessibility/')}>Accessibility Guide</a> for keyboard interaction,
+focus management, ARIA patterns, and testing checklists.
+
 ## License
 
 MIT.

--- a/apps/website/src/pages/accessibility.mdx
+++ b/apps/website/src/pages/accessibility.mdx
@@ -1,0 +1,75 @@
+---
+layout: ../layouts/MarkdownLayout.astro
+title: Accessibility Guide
+description: Keyboard interaction, focus management, ARIA patterns, and testing checklists for building with GHDS.
+---
+
+import KeyboardTable from '../components/KeyboardTable.astro';
+import { withBase } from '../lib/withBase';
+
+This is reference documentation for building accessible screens with GHDS — see
+<a href={withBase('/about/')}>About &amp; Accessibility</a> for the project's overall accessibility
+commitment and how the automated color-contrast validation works.
+
+## Keyboard Interaction
+
+Every component that exists today (`Button`, `Card`, `Input`) relies entirely on native browser
+keyboard handling — none of them has custom `onKeyDown` or `tabIndex` logic.
+
+<KeyboardTable
+  rows={[
+    { keys: 'Tab', action: 'Move focus to the next focusable element in document order.' },
+    { keys: 'Shift + Tab', action: 'Move focus to the previous focusable element.' },
+    { keys: 'Enter / Space', action: 'Activate a focused Button.' },
+  ]}
+/>
+
+Components that don't exist yet (Modal, Toast, Tooltip, Menu — M11) will need their own key
+bindings (typically `Escape` to dismiss, arrow keys for menu navigation); this table will grow as
+they ship.
+
+## Focus Management
+
+- **Visible focus**: `Button` and `Input` each track their own `focused` state and render a visible
+  ring using a `comp.*.focus.ring` or `border-focus` token — never rely on removing the outline
+  without replacing it.
+- **Tab order**: a native HTML `disabled` attribute (used by `Button`'s default render path)
+  removes the element from the tab order entirely. `Button`'s `asChild` path only sets
+  `aria-disabled`, which does **not** remove it from the tab order — if you disable an `asChild`
+  button, you must also prevent activation yourself.
+- **Focus trap / restore**: no component implements this today, because no overlay component
+  (Modal, Drawer, Menu) exists yet. When one ships, the standard is: trap Tab/Shift+Tab within the
+  overlay while open, and restore focus to the element that opened it on close. This is forward
+  guidance for M11, not a description of current behavior.
+
+## ARIA Pattern Reference
+
+| Component | Pattern |
+| --- | --- |
+| `Button` | Native `<button>` role (or `aria-disabled` on the `asChild` path — see Keyboard Interaction above). Decorative sketch outline is `aria-hidden="true"`. |
+| `Card` | No role by default on React — the caller supplies one. Web Components/React Native automatically expose `role="group"`/`accessibilityRole="summary"` when a `label` is given. |
+| `Input` | `aria-invalid` + `aria-describedby` (pointing at a `role="alert"` error message) on React when `error` is set. Label association via `<label for>`/Radix `Label`. |
+
+## Screen Reader Testing Checklist
+
+- [ ] Every interactive element (`Button`, `Input`) has an accessible name — either visible text,
+  a `label`, or an explicit `aria-label`/`accessibilityLabel`.
+- [ ] Disabling a component removes it from both the tab order **and** screen reader interaction
+  — verify both, since (per Focus Management above) they don't always happen together.
+- [ ] An `Input`'s error message is announced when it appears, not just visually shown.
+- [ ] Decorative elements (the sketch outline SVGs) are silent — confirm they don't get announced
+  or receive focus.
+- [ ] Toggling dark mode doesn't change any of the above (the `[data-theme]` switch is purely
+  visual).
+
+## How Color Contrast Validation Works
+
+Every `sys.color.*` text/background pairing is checked automatically at build time in
+`@ghds/tokens` — the check computes the real WCAG relative-luminance contrast ratio for every
+`text`/`icon`/`border` role against every `bg` surface, plus explicit text-on-filled-background
+pairs, and asserts 4.5:1 for normal text or 3:1 for large text/icons/borders. A small, documented
+set of pairs (disabled text/background, decorative borders) is exempt.
+
+**What this means for you**: you get the WCAG 2.1 AA guarantee for free *as long as you consume
+`sys.color.*` (or `comp.*` tokens that alias them)* — the guarantee does not extend to any custom
+color you introduce outside the token set, or to the exempt pairs above.

--- a/apps/website/src/pages/components.astro
+++ b/apps/website/src/pages/components.astro
@@ -2,6 +2,7 @@
 import LitDemo from '../components/LitDemo.astro';
 import ReactDemo from '../components/ReactDemo';
 import BaseLayout from '../layouts/BaseLayout.astro';
+import { withBase } from '../lib/withBase';
 ---
 
 <BaseLayout
@@ -42,5 +43,23 @@ import BaseLayout from '../layouts/BaseLayout.astro';
       but the visual result is identical. This is why tokens are kept as the single source of
       truth — change a value in one place, and every framework changes with it.
     </p>
+  </section>
+
+  <section class="section">
+    <h2>Component Documentation</h2>
+    <p>Anatomy, variants &amp; states, accessibility, props, and a live demo for each component:</p>
+    <ul>
+      <li>
+        <a href={withBase('/components/button/')}>Button</a> — variants, states, accessibility,
+        and props
+      </li>
+      <li>
+        <a href={withBase('/components/card/')}>Card</a> — a generic hand-drawn surface container
+      </li>
+      <li>
+        <a href={withBase('/components/input/')}>Input</a> — a labeled text field with an error
+        state
+      </li>
+    </ul>
   </section>
 </BaseLayout>

--- a/apps/website/src/pages/components.astro
+++ b/apps/website/src/pages/components.astro
@@ -60,6 +60,10 @@ import { withBase } from '../lib/withBase';
         <a href={withBase('/components/input/')}>Input</a> — a labeled text field with an error
         state
       </li>
+      <li>
+        <a href={withBase('/accessibility/')}>Accessibility Guide</a> — keyboard interaction,
+        focus management, and ARIA patterns shared across all components
+      </li>
     </ul>
   </section>
 </BaseLayout>

--- a/apps/website/src/pages/components/button.mdx
+++ b/apps/website/src/pages/components/button.mdx
@@ -1,0 +1,144 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Button
+description: The reference implementation of the GHDS component documentation standard.
+---
+
+import PropsTable from '../../components/PropsTable.astro';
+import StateList from '../../components/StateList.astro';
+import DoDont from '../../components/DoDont.astro';
+import ButtonDemoReact from '../../components/demos/ButtonDemo.tsx';
+import ButtonDemoLit from '../../components/demos/ButtonDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+This page is the reference implementation of the GHDS component documentation standard — every
+future component page (Card, Input, and everything in M10/M11) follows the same eight sections in
+the same order.
+
+## Overview
+
+A `Button` triggers a single, immediate, user-initiated action — submitting a form, confirming a
+choice, opening something. Use a link (or `asChild` with an `<a>`) instead when the destination is
+navigation, not an action.
+
+## Anatomy
+
+A real `<button>` (or a Radix `Slot`-rendered element via `asChild`) carries all native keyboard
+and click semantics. A hand-drawn `SketchSurface` outline sits behind the label, purely decorative
+(`aria-hidden="true"`, `focusable="false"`, with an SVG `<title>` for tooling) — it never carries
+meaning, so removing it never changes what the button does or how it's announced.
+
+## Variants & States
+
+Exactly three variants exist: `primary`, `danger`, `neutral` — there is no `secondary`, `ghost`, or
+`link` variant.
+
+<StateList
+  states={[
+    { name: 'Default', present: true },
+    { name: 'Hover', present: true, note: 'Fill/text color shifts per variant.' },
+    { name: 'Active / pressed', present: true },
+    {
+      name: 'Focus',
+      present: true,
+      note: 'A manual focus ring (comp.button.focus.ring), not native :focus-visible.',
+    },
+    { name: 'Disabled', present: true },
+    { name: 'Loading', present: false },
+    { name: 'Error', present: false },
+  ]}
+/>
+
+## Usage
+
+<DoDont
+  do={[
+    'Use danger only for destructive or irreversible actions.',
+    'Use asChild to keep link semantics when a button needs to look and behave like a link.',
+    'Keep one primary button per view — it should be obvious what the main action is.',
+  ]}
+  dont={[
+    "Don't rely on color alone to convey a danger action — the label should say what happens.",
+    "Don't disable a button without explaining why somewhere else on screen.",
+    "Don't nest an <a> inside a native <button> — use asChild instead.",
+  ]}
+/>
+
+## Accessibility
+
+- Native `<button>` keyboard behavior (Space/Enter activates, native tab order) comes for free —
+  no custom `onKeyDown` or `tabIndex` exists in the implementation.
+- Disabling is **not** uniform across the two render paths: the native `<button disabled>` path
+  removes the element from the tab order entirely (the browser's native behavior), while the
+  `asChild` path only sets `aria-disabled` — which does *not* remove the element from the tab
+  order. If you disable an `asChild` button, you're responsible for also preventing activation.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a> for the general keyboard
+  and ARIA conventions shared across all components.
+
+## Content
+
+Labels are short verb phrases — "Delete", "Cancel", "Save changes" — not sentences, and carry no
+trailing punctuation.
+
+## Props API
+
+<PropsTable
+  groups={[
+    {
+      platform: 'React',
+      packageName: '@ghds/react',
+      rows: [
+        { name: 'variant', type: "'primary' | 'danger' | 'neutral'", default: "'primary'", description: 'Visual intent.' },
+        { name: 'asChild', type: 'boolean', default: 'false', description: 'Render as the single child element (Radix Slot) instead of a <button>.' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Disables interaction.' },
+        { name: 'type', type: "'button' | 'submit' | 'reset'", default: "'button'", description: 'Native button type.' },
+        { name: '...rest', type: 'ButtonHTMLAttributes', description: 'All other native <button> attributes pass through.' },
+      ],
+    },
+    {
+      platform: 'Web Components',
+      packageName: '@ghds/web-components',
+      rows: [
+        { name: 'variant', type: "'primary' | 'danger' | 'neutral'", default: "'primary'", description: 'Reflected attribute.' },
+        { name: 'type', type: "'button' | 'submit' | 'reset'", default: "'button'", description: 'Drives form association (formAssociated = true).' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Reflected attribute.' },
+      ],
+    },
+    {
+      platform: 'React Native',
+      packageName: '@ghds/react-native',
+      rows: [
+        { name: 'label', type: 'string', description: 'Visible, accessible label — required (no children).' },
+        { name: 'onPress', type: '(event: GestureResponderEvent) => void', description: 'Press handler.' },
+        { name: 'variant', type: "'primary' | 'danger'", default: "'primary'", description: 'No neutral variant on React Native.' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Disables interaction.' },
+        { name: 'testID', type: 'string', description: 'Test handle for queries.' },
+        { name: 'accessibilityHint', type: 'string', description: "Supplementary a11y hint describing the action's outcome." },
+      ],
+    },
+  ]}
+/>
+
+## Live Demo
+
+React and Web Components render live below, driven by the same tokens — toggle dark mode in the
+header to see both respond identically. React Native can't run in a browser without additional
+`react-native-web` wiring (not set up in this site), so its usage is shown as a code sample instead.
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <ButtonDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <ButtonDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native
+import { Button } from '@ghds/react-native';
+
+<Button label="Delete" variant="danger" onPress={() => {}} />;
+```

--- a/apps/website/src/pages/components/card.mdx
+++ b/apps/website/src/pages/components/card.mdx
@@ -1,0 +1,126 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Card
+description: A generic hand-drawn surface container for grouping related content.
+---
+
+import PropsTable from '../../components/PropsTable.astro';
+import StateList from '../../components/StateList.astro';
+import DoDont from '../../components/DoDont.astro';
+import CardDemoReact from '../../components/demos/CardDemo.tsx';
+import CardDemoLit from '../../components/demos/CardDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+## Overview
+
+A `Card` is a generic surface for grouping related content — it isn't interactive by itself and
+carries no built-in meaning beyond "these things belong together."
+
+## Anatomy
+
+A sketchy rectangle outline drawn behind plain children. On Web Components, content slotted as
+`<h1>`/`<h2>`/`<h3>`/`[slot="title"]` gets special title styling (`::slotted` CSS); React and
+React Native have no equivalent title slot — content is just plain children.
+
+## Variants & States
+
+Unlike Button and Input, Card is mostly a **static container** — this section is intentionally
+thin rather than force-fitting states that don't exist.
+
+<StateList
+  states={[
+    { name: 'Hover', present: false, note: 'Card is not interactive.' },
+    { name: 'Focus', present: false, note: 'Card is not focusable.' },
+    { name: 'Disabled', present: false },
+    { name: 'Loading', present: false },
+    { name: 'Error', present: false },
+  ]}
+/>
+
+The one real variation is a **different prop per platform**, not a shared state: React's `fill`
+(`'solid' | 'hachure'`) controls the fill pattern; Web Components and React Native instead expose
+`elevated` (a boolean drop-shadow effect) — a genuinely different API, not a superset of React's.
+
+## Usage
+
+<DoDont
+  do={[
+    "Supply your own role/aria-label (React) or label (WC/RN) when the card functions as a landmark or region.",
+    'Use Card for visual grouping (a settings panel, a list item) rather than as a substitute for semantic HTML.',
+  ]}
+  dont={[
+    "Don't expect a role or accessible name automatically on React — the caller is fully responsible for it there.",
+    "Don't rely on fill and elevated meaning the same thing across platforms — they're different props with different visual effects.",
+  ]}
+/>
+
+## Accessibility
+
+- **React**: renders a plain `<div>`. No role or label is set automatically — "any ARIA role/
+  landmark is the caller's to set" (per the component's own doc comment).
+- **Web Components**: when a `label` is supplied, `gh-card` automatically sets
+  `internals.role = 'group'` and `internals.ariaLabel` — a real behavior React does *not* replicate.
+- **React Native**: sets `accessibilityRole="summary"` only when `accessibilityLabel` is passed.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a> for general conventions.
+
+## Content
+
+N/A — Card has no fixed content model. Content is whatever the caller passes as children (React/RN)
+or slots (Web Components).
+
+## Props API
+
+<PropsTable
+  groups={[
+    {
+      platform: 'React',
+      packageName: '@ghds/react',
+      rows: [
+        { name: 'fill', type: "'solid' | 'hachure'", default: "'solid'", description: 'Fill style of the card body.' },
+        { name: '...rest', type: 'HTMLAttributes<HTMLDivElement>', description: 'Native <div> attributes (e.g. role, aria-label) pass through.' },
+      ],
+    },
+    {
+      platform: 'Web Components',
+      packageName: '@ghds/web-components',
+      rows: [
+        { name: 'elevated', type: 'boolean', default: 'false', description: 'Renders a sketch drop-shadow outline. No fill prop exists.' },
+        { name: 'label', type: 'string', description: 'When set, exposes the card as an ARIA group with this label.' },
+      ],
+    },
+    {
+      platform: 'React Native',
+      packageName: '@ghds/react-native',
+      rows: [
+        { name: 'elevated', type: 'boolean', default: 'false', description: 'Same effect as Web Components. No fill prop.' },
+        { name: 'accessibilityLabel', type: 'string', description: 'When set, accessibilityRole becomes "summary".' },
+        { name: 'testID', type: 'string', description: 'Test handle for queries.' },
+      ],
+    },
+  ]}
+/>
+
+## Live Demo
+
+React uses `fill`; Web Components uses `elevated` + `label` — the demo below deliberately shows
+each platform's *actual* prop, not a unified example.
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <CardDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <CardDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native
+import { Card } from '@ghds/react-native';
+
+<Card elevated accessibilityLabel="Summary">
+  <Text>Elevated card content</Text>
+</Card>;
+```

--- a/apps/website/src/pages/components/input.mdx
+++ b/apps/website/src/pages/components/input.mdx
@@ -19,7 +19,7 @@ React) an error message.
 ## Anatomy
 
 An optional label above a sketchy-outlined text box; on React, an error message renders below the
-box as an `role="alert"` element when `error` is set.
+box as a `role="alert"` element when `error` is set.
 
 ## Variants & States
 

--- a/apps/website/src/pages/components/input.mdx
+++ b/apps/website/src/pages/components/input.mdx
@@ -1,0 +1,142 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Input
+description: A single-line hand-drawn text field with an optional label and error message.
+---
+
+import PropsTable from '../../components/PropsTable.astro';
+import StateList from '../../components/StateList.astro';
+import DoDont from '../../components/DoDont.astro';
+import InputDemoReact from '../../components/demos/InputDemo.tsx';
+import InputDemoLit from '../../components/demos/InputDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+## Overview
+
+A single-line text field for collecting a piece of data, with an optional visible label and (on
+React) an error message.
+
+## Anatomy
+
+An optional label above a sketchy-outlined text box; on React, an error message renders below the
+box as an `role="alert"` element when `error` is set.
+
+## Variants & States
+
+<StateList
+  states={[
+    { name: 'Default', present: true },
+    { name: 'Focused', present: true, note: 'Stroke color swaps to a focus token.' },
+    { name: 'Disabled', present: true },
+    {
+      name: 'Error / invalid',
+      present: true,
+      note: 'React only — aria-invalid + aria-describedby + role="alert". Not implemented on Web Components or React Native.',
+    },
+    { name: 'Loading', present: false },
+  ]}
+/>
+
+Web Components instead has `required` (native constraint validation via `ElementInternals`) —
+React and React Native don't expose that as a prop at all. These are two separate, real gaps, not
+documentation omissions: don't show an error demo for Web Components or React Native.
+
+## Usage
+
+<DoDont
+  do={[
+    'Always pair error with a specific, actionable message ("Please enter at least 8 characters."), not a generic "Invalid input."',
+    'Keep label visible rather than relying on placeholder text alone.',
+  ]}
+  dont={[
+    "Don't rely on placeholder text as the only accessible name — it disappears once the user types.",
+    "Don't show more than one error message per field.",
+  ]}
+/>
+
+## Accessibility
+
+- **React**: `aria-invalid` + `aria-describedby` (pointing at the error `<span role="alert">`) +
+  Radix `Label`/`htmlFor` association.
+- **Web Components**: `label`/`for` association; `aria-label` falls back to the placeholder when no
+  label is set. No invalid-state ARIA exists today.
+- **React Native**: `accessibilityLabel` falls back to `placeholder`; `accessibilityState={{disabled}}`
+  has no error/invalid concept.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a> for general conventions.
+
+## Content
+
+The label names the data being collected ("Email", "Password"), not an action — contrast with
+Button, whose label names an action. Error messages state what's wrong and how to fix it.
+
+## Props API
+
+<PropsTable
+  groups={[
+    {
+      platform: 'React',
+      packageName: '@ghds/react',
+      rows: [
+        { name: 'label', type: 'string', description: 'Visible label, associated via Radix Label.' },
+        { name: 'error', type: 'string', description: 'Error message. When set, marks the field invalid and announces it.' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Disables editing.' },
+        { name: '...rest', type: 'InputHTMLAttributes', description: 'All other native <input> attributes (value, onChange, etc.) pass through.' },
+      ],
+    },
+    {
+      platform: 'Web Components',
+      packageName: '@ghds/web-components',
+      rows: [
+        { name: 'value', type: 'string', default: "''", description: 'Current field value, mirrored to the form value.' },
+        { name: 'name', type: 'string', description: 'Submitted control name.' },
+        { name: 'type', type: "'text' | 'email' | 'password' | 'search' | 'tel' | 'url' | 'number'", default: "'text'", description: 'Input mode.' },
+        { name: 'placeholder', type: 'string', description: 'Placeholder text.' },
+        { name: 'label', type: 'string', description: 'Optional visible label, also the accessible name.' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Disables editing and form participation.' },
+        { name: 'required', type: 'boolean', default: 'false', description: 'Native constraint validation. No error prop exists.' },
+      ],
+    },
+    {
+      platform: 'React Native',
+      packageName: '@ghds/react-native',
+      rows: [
+        { name: 'value', type: 'string', description: 'Controlled text value.' },
+        { name: 'onChangeText', type: '(text: string) => void', description: 'Change handler.' },
+        { name: 'placeholder', type: 'string', description: 'Placeholder; also the default a11y label.' },
+        { name: 'disabled', type: 'boolean', default: 'false', description: 'Disables editing.' },
+        { name: 'accessibilityLabel', type: 'string', description: 'Falls back to placeholder.' },
+        { name: 'keyboardType', type: "TextInputProps['keyboardType']", description: 'Keyboard variant.' },
+        { name: 'secureTextEntry', type: 'boolean', description: 'Masks input for passwords. No error prop exists.' },
+        { name: 'testID', type: 'string', description: 'Test handle for queries.' },
+      ],
+    },
+  ]}
+/>
+
+## Live Demo
+
+React's demo includes the error state; the Web Components demo intentionally does not (it has no
+error prop) and shows `required` instead.
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <InputDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <InputDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native
+import { Input } from '@ghds/react-native';
+
+<Input
+  value={email}
+  onChangeText={setEmail}
+  placeholder="you@example.com"
+  keyboardType="email-address"
+/>;
+```

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -401,6 +401,18 @@ code {
   margin-bottom: var(--sys-spacing-sm);
 }
 
+/* ---- Component doc primitives (PropsTable / StateList / DoDont) ----- */
+
+.props-group {
+  margin-bottom: var(--sys-spacing-xl);
+}
+
+.do-dont {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(16rem, 1fr));
+  gap: var(--sys-spacing-lg);
+}
+
 /* ---- Prose (MDX content pages) -------------------------------------- */
 
 .prose {


### PR DESCRIPTION
## Summary
- Adds a reusable component documentation template — `PropsTable`/`StateList`/`DoDont`/`KeyboardTable` Astro components — proven on a Button reference page (`/components/button/`), then retrofitted onto Card and Input (`/components/card/`, `/components/input/`) — closes GHD-28 and GHD-30.
- Adds a standalone Accessibility Guide (`/accessibility/`) covering keyboard interaction, focus management, ARIA pattern reference, a screen-reader testing checklist, and how the automated WCAG AA contrast validation works for consumers — closes GHD-29.
- Every Props/States table reflects the *real* per-platform component API — including genuine gaps (Card's `fill` (React) vs `elevated` (Web Components/React Native), Input's error state being React-only) — rather than presenting a fabricated unified story across platforms.
- `components.astro` and `about.mdx` gain cross-links to the new pages; no `nav.ts` changes (kept as one-click-deeper detail pages, per the milestone's IA decision).

## Test plan
- [x] `pnpm --filter @ghds/website lint` and `build` pass; all 4 new routes (`/components/button/`, `/components/card/`, `/components/input/`, `/accessibility/`) generate correctly
- [x] Verified every Props table row against the actual component source in `packages/react`, `packages/web-components`, and `packages/react-native` — no invented props or states
- [x] Verified all cross-page links carry the GitHub Pages base path
- [x] Checked for a recurrence of a previously-found Astro compiler bug (dynamic `{}` expression as sole child of `<code>` in a table cell) — not present in this diff
- [x] `pnpm --filter @ghds/react test` (26 tests) still passes
- [x] Reviewed via automated code-review workflow (high effort); found and fixed 1 issue — Input's React Native Props table was missing the `testID` prop that the real component supports (Button/Card's RN tables already had it)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added new component documentation pages for Button, Card, and Input, including live examples, usage guidance, accessibility notes, and platform-specific prop tables.
  * Added an accessibility guide page covering keyboard interaction, focus behavior, screen reader checks, and contrast guidance.
  * Added reusable documentation sections for do/don’t guidance, keyboard shortcuts, prop tables, and state lists.
  * Added live demos for Button, Card, and Input components across supported platforms.

* **Documentation**
  * Updated the components index and About page to better surface accessibility and documentation resources.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->