### PR TITLE
docs(repo): complete M11 a11y guide docs and M12 pattern library (GHD-35/37/38/39)

### DIFF
--- a/apps/website/src/components/demos/PatternDataDemo.astro
+++ b/apps/website/src/components/demos/PatternDataDemo.astro
@@ -1,0 +1,37 @@
+---
+// Live demo of data patterns — searchable product table using Web Components.
+---
+
+<div class="demo-stack" style="gap: var(--sys-spacing-md, 16px)">
+  <gh-input id="data-search" placeholder="Search products..." type="search"></gh-input>
+  <gh-table id="data-table"></gh-table>
+</div>
+
+<script>
+  import '@ghds/web-components';
+
+  const products = [
+    { id: '1', name: 'Wireless Mouse', price: '$29.99', stock: 'In stock' },
+    { id: '2', name: 'USB-C Hub', price: '$49.99', stock: 'Low stock' },
+    { id: '3', name: 'Mechanical Keyboard', price: '$89.99', stock: 'In stock' },
+    { id: '4', name: 'Webcam HD', price: '$59.99', stock: 'Out of stock' },
+    { id: '5', name: 'Monitor Stand', price: '$39.99', stock: 'In stock' },
+  ];
+
+  const search = document.getElementById('data-search');
+  const table = /** @type {import('@ghds/web-components').GhTable} */ (
+    document.getElementById('data-table')
+  );
+
+  table.columns = [
+    { key: 'name', header: 'Name', sortable: true },
+    { key: 'price', header: 'Price', sortable: true },
+    { key: 'stock', header: 'Stock', sortable: true },
+  ];
+  table.rows = products;
+
+  search?.addEventListener('input', (e) => {
+    const q = /** @type {string} */ (e.target?.value || '').toLowerCase();
+    table.rows = q ? products.filter((p) => p.name.toLowerCase().includes(q)) : products;
+  });
+</script>

--- a/apps/website/src/components/demos/PatternDataDemo.tsx
+++ b/apps/website/src/components/demos/PatternDataDemo.tsx
@@ -31,9 +31,7 @@ export default function PatternDataDemo(): React.JSX.Element {
   const [query, setQuery] = useState('');
   const [loading, setLoading] = useState(false);
 
-  const filtered = PRODUCTS.filter((p) =>
-    p.name.toLowerCase().includes(query.toLowerCase()),
-  );
+  const filtered = PRODUCTS.filter((p) => p.name.toLowerCase().includes(query.toLowerCase()));
 
   const handleSearch = (value: string) => {
     setQuery(value);
@@ -49,7 +47,9 @@ export default function PatternDataDemo(): React.JSX.Element {
         onChange={(e) => handleSearch((e.target as HTMLInputElement).value)}
       />
       {loading ? (
-        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--sys-spacing-lg)' }}>
+        <div
+          style={{ display: 'flex', justifyContent: 'center', padding: 'var(--sys-spacing-lg)' }}
+        >
           <Spinner />
         </div>
       ) : filtered.length === 0 ? (

--- a/apps/website/src/components/demos/PatternDataDemo.tsx
+++ b/apps/website/src/components/demos/PatternDataDemo.tsx
@@ -1,0 +1,73 @@
+import { Input, Spinner, Table, type TableColumn, type TableRow } from '@ghds/react';
+import { useState } from 'react';
+
+interface Product extends TableRow {
+  name: string;
+  price: number;
+  stock: string;
+}
+
+const PRODUCTS: Product[] = [
+  { id: '1', name: 'Wireless Mouse', price: 29.99, stock: 'In stock' },
+  { id: '2', name: 'USB-C Hub', price: 49.99, stock: 'Low stock' },
+  { id: '3', name: 'Mechanical Keyboard', price: 89.99, stock: 'In stock' },
+  { id: '4', name: 'Webcam HD', price: 59.99, stock: 'Out of stock' },
+  { id: '5', name: 'Monitor Stand', price: 39.99, stock: 'In stock' },
+];
+
+const COLUMNS: TableColumn<Product>[] = [
+  { key: 'name', header: 'Name', sortable: true },
+  {
+    key: 'price',
+    header: 'Price',
+    sortable: true,
+    render: (row) => `$${row.price.toFixed(2)}`,
+  },
+  { key: 'stock', header: 'Stock', sortable: true },
+];
+
+/** Live demo of data patterns — searchable product table with loading simulation. */
+export default function PatternDataDemo(): React.JSX.Element {
+  const [query, setQuery] = useState('');
+  const [loading, setLoading] = useState(false);
+
+  const filtered = PRODUCTS.filter((p) =>
+    p.name.toLowerCase().includes(query.toLowerCase()),
+  );
+
+  const handleSearch = (value: string) => {
+    setQuery(value);
+    setLoading(true);
+    setTimeout(() => setLoading(false), 600);
+  };
+
+  return (
+    <div className="demo-stack" style={{ gap: 'var(--sys-spacing-md, 16px)' }}>
+      <Input
+        placeholder="Search products..."
+        value={query}
+        onChange={(e) => handleSearch((e.target as HTMLInputElement).value)}
+      />
+      {loading ? (
+        <div style={{ display: 'flex', justifyContent: 'center', padding: 'var(--sys-spacing-lg)' }}>
+          <Spinner />
+        </div>
+      ) : filtered.length === 0 ? (
+        <div
+          style={{
+            textAlign: 'center',
+            padding: 'var(--sys-spacing-xl)',
+            color: 'var(--comp-input-text, inherit)',
+          }}
+        >
+          <p>No results for "{query}".</p>
+          <p style={{ fontSize: 'var(--sys-typography-caption-fontSize, 0.875rem)' }}>
+            Try a different search term.
+          </p>
+        </div>
+      ) : (
+        <Table columns={COLUMNS} rows={filtered} />
+      )}
+    </div>
+  );
+}

--- a/apps/website/src/components/demos/PatternFeedbackDemo.astro
+++ b/apps/website/src/components/demos/PatternFeedbackDemo.astro
@@ -1,0 +1,52 @@
+---
+// Live demo of feedback patterns — alert, toast buttons, and modal using Web Components.
+---
+
+<div class="demo-stack" style="gap: var(--sys-spacing-md, 16px)">
+  <gh-alert variant="info" heading="Maintenance notice" dismissible>
+    The system will be updated tonight at 2 AM UTC. Your work will not be affected.
+  </gh-alert>
+
+  <div class="demo-row">
+    <gh-button variant="primary" id="toast-success">success</gh-button>
+    <gh-button variant="danger" id="toast-danger">danger</gh-button>
+    <gh-button variant="neutral" id="toast-warning">warning</gh-button>
+    <gh-button variant="primary" id="toast-info">info</gh-button>
+  </div>
+
+  <gh-button variant="danger" id="open-modal">Delete account</gh-button>
+
+  <gh-toast id="feedback-toast" duration="0"></gh-toast>
+
+  <gh-modal id="feedback-modal" heading="Delete account?">
+    <p style="margin-top: 0">This action cannot be undone. All your data will be permanently removed.</p>
+    <div style="display: flex; gap: var(--sys-spacing-sm); justify-content: flex-end">
+      <gh-button variant="neutral" id="cancel-modal">Cancel</gh-button>
+      <gh-button variant="danger" id="confirm-modal">Delete</gh-button>
+    </div>
+  </gh-modal>
+</div>
+
+<script>
+  import '@ghds/web-components';
+
+  const toast = document.getElementById('feedback-toast');
+  const modal = document.getElementById('feedback-modal');
+
+  ['success', 'danger', 'warning', 'info'].forEach((v) => {
+    document.getElementById(`toast-${v}`)?.addEventListener('click', () => {
+      toast.variant = v;
+      toast.heading = v.charAt(0).toUpperCase() + v.slice(1);
+      toast.textContent = `This is a ${v} toast message.`;
+      toast.open = true;
+    });
+  });
+
+  document.getElementById('open-modal')?.addEventListener('click', () => {
+    modal.open = true;
+  });
+
+  modal?.addEventListener('close', () => { modal.open = false; });
+  document.getElementById('cancel-modal')?.addEventListener('click', () => { modal.open = false; });
+  document.getElementById('confirm-modal')?.addEventListener('click', () => { modal.open = false; });
+</script>

--- a/apps/website/src/components/demos/PatternFeedbackDemo.tsx
+++ b/apps/website/src/components/demos/PatternFeedbackDemo.tsx
@@ -1,0 +1,63 @@
+import { Alert, Button, Modal, Toast, type ToastVariant } from '@ghds/react';
+import { useState } from 'react';
+
+const VARIANTS: ToastVariant[] = ['success', 'danger', 'warning', 'info'];
+
+/** Live demo of feedback patterns — toast, alert, and modal side by side. */
+export default function PatternFeedbackDemo(): React.JSX.Element {
+  const [toast, setToast] = useState<{ open: boolean; variant: ToastVariant }>({
+    open: false,
+    variant: 'success',
+  });
+  const [showModal, setShowModal] = useState(false);
+
+  return (
+    <div className="demo-stack" style={{ gap: 'var(--sys-spacing-md, 16px)' }}>
+      <Alert variant="info" title="Maintenance notice">
+        The system will be updated tonight at 2 AM UTC. Your work will not be affected.
+      </Alert>
+
+      <div className="demo-row">
+        {VARIANTS.map((v) => (
+          <Button
+            key={v}
+            variant={v === 'danger' ? 'danger' : v === 'warning' ? 'neutral' : 'primary'}
+            onClick={() => setToast({ open: true, variant: v })}
+          >
+            {v}
+          </Button>
+        ))}
+      </div>
+
+      <Button variant="danger" onClick={() => setShowModal(true)}>
+        Delete account
+      </Button>
+
+      <Toast
+        open={toast.open}
+        onClose={() => setToast((t) => ({ ...t, open: false }))}
+        variant={toast.variant}
+        title={toast.variant.charAt(0).toUpperCase() + toast.variant.slice(1)}
+        duration={0}
+      >
+        This is a {toast.variant} toast message.
+      </Toast>
+
+      <Modal open={showModal} onClose={() => setShowModal(false)} title="Delete account?">
+        <p style={{ marginTop: 0 }}>
+          This action cannot be undone. All your data will be permanently removed.
+        </p>
+        <div
+          style={{ display: 'flex', gap: 'var(--sys-spacing-sm)', justifyContent: 'flex-end' }}
+        >
+          <Button variant="neutral" onClick={() => setShowModal(false)}>
+            Cancel
+          </Button>
+          <Button variant="danger" onClick={() => setShowModal(false)}>
+            Delete
+          </Button>
+        </div>
+      </Modal>
+    </div>
+  );
+}

--- a/apps/website/src/components/demos/PatternFeedbackDemo.tsx
+++ b/apps/website/src/components/demos/PatternFeedbackDemo.tsx
@@ -47,9 +47,7 @@ export default function PatternFeedbackDemo(): React.JSX.Element {
         <p style={{ marginTop: 0 }}>
           This action cannot be undone. All your data will be permanently removed.
         </p>
-        <div
-          style={{ display: 'flex', gap: 'var(--sys-spacing-sm)', justifyContent: 'flex-end' }}
-        >
+        <div style={{ display: 'flex', gap: 'var(--sys-spacing-sm)', justifyContent: 'flex-end' }}>
           <Button variant="neutral" onClick={() => setShowModal(false)}>
             Cancel
           </Button>

--- a/apps/website/src/components/demos/PatternFormDemo.astro
+++ b/apps/website/src/components/demos/PatternFormDemo.astro
@@ -1,0 +1,24 @@
+---
+// Live demo of form patterns — login form using Web Components.
+---
+
+<div class="demo-stack" style="gap: var(--comp-formField-gap, var(--sys-spacing-md, 16px))">
+  <gh-form-field label="Email">
+    <gh-input placeholder="you@example.com" type="email"></gh-input>
+  </gh-form-field>
+  <gh-form-field label="Password" helper-text="At least 8 characters">
+    <gh-input type="password"></gh-input>
+  </gh-form-field>
+  <gh-form-field label="Role">
+    <gh-select value="viewer">
+      <gh-select-option value="admin">Admin</gh-select-option>
+      <gh-select-option value="editor">Editor</gh-select-option>
+      <gh-select-option value="viewer">Viewer</gh-select-option>
+    </gh-select>
+  </gh-form-field>
+  <gh-button variant="primary">Log in</gh-button>
+</div>
+
+<script>
+  import '@ghds/web-components';
+</script>

--- a/apps/website/src/components/demos/PatternFormDemo.tsx
+++ b/apps/website/src/components/demos/PatternFormDemo.tsx
@@ -1,0 +1,44 @@
+import { Button, FormField, Input, Select, SelectOption } from '@ghds/react';
+import { useState } from 'react';
+
+/** Live demo of form patterns — login form with validation. */
+export default function PatternFormDemo(): React.JSX.Element {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [submitted, setSubmitted] = useState(false);
+
+  const emailError = submitted && !email ? 'Email is required.' : '';
+  const passwordError = submitted && password.length < 8 ? 'Must be at least 8 characters.' : '';
+
+  return (
+    <div
+      className="demo-stack"
+      style={{ gap: 'var(--comp-formField-gap, var(--sys-spacing-md, 16px))' }}
+    >
+      <FormField label="Email" error={emailError}>
+        <Input
+          placeholder="you@example.com"
+          value={email}
+          onChange={(e) => setEmail((e.target as HTMLInputElement).value)}
+        />
+      </FormField>
+      <FormField label="Password" error={passwordError} helperText="At least 8 characters">
+        <Input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword((e.target as HTMLInputElement).value)}
+        />
+      </FormField>
+      <FormField label="Role">
+        <Select value="viewer">
+          <SelectOption value="admin">Admin</SelectOption>
+          <SelectOption value="editor">Editor</SelectOption>
+          <SelectOption value="viewer">Viewer</SelectOption>
+        </Select>
+      </FormField>
+      <Button variant="primary" onClick={() => setSubmitted(true)}>
+        Log in
+      </Button>
+    </div>
+  );
+}

--- a/apps/website/src/pages/accessibility.mdx
+++ b/apps/website/src/pages/accessibility.mdx
@@ -13,20 +13,19 @@ commitment and how the automated color-contrast validation works.
 
 ## Keyboard Interaction
 
-Every component that exists today (`Button`, `Card`, `Input`) relies entirely on native browser
-keyboard handling — none of them has custom `onKeyDown` or `tabIndex` logic.
+Most components (`Button`, `Card`, `Input`, `Alert`, `Badge`, `Avatar`, `Spinner`, `Progress`,
+`Skeleton`, `Table`) rely entirely on native browser keyboard handling — no custom `onKeyDown` or
+`tabIndex` logic. Overlay components add their own bindings for dismissal and navigation.
 
 <KeyboardTable
   rows={[
     { keys: 'Tab', action: 'Move focus to the next focusable element in document order.' },
     { keys: 'Shift + Tab', action: 'Move focus to the previous focusable element.' },
     { keys: 'Enter / Space', action: 'Activate a focused Button.' },
+    { keys: 'Escape', action: 'Close an open Modal (dismisses the dialog and restores focus to the trigger). Also dismisses Tooltip and Menu.' },
+    { keys: '↑ ↓ ← →', action: 'Navigate items within an open Menu (arrow keys), or cycle through Tabs (left/right arrows).' },
   ]}
 />
-
-Components that don't exist yet (Modal, Toast, Tooltip, Menu — M11) will need their own key
-bindings (typically `Escape` to dismiss, arrow keys for menu navigation); this table will grow as
-they ship.
 
 ## Focus Management
 
@@ -37,10 +36,12 @@ they ship.
   removes the element from the tab order entirely. `Button`'s `asChild` path only sets
   `aria-disabled`, which does **not** remove it from the tab order — if you disable an `asChild`
   button, you must also prevent activation yourself.
-- **Focus trap / restore**: no component implements this today, because no overlay component
-  (Modal, Drawer, Menu) exists yet. When one ships, the standard is: trap Tab/Shift+Tab within the
-  overlay while open, and restore focus to the element that opened it on close. This is forward
-  guidance for M11, not a description of current behavior.
+- **Focus trap / restore**: `Modal` implements full focus-trap+restore on React and Web Components.
+  On open, focus moves to the first focusable element inside the dialog (or the dialog itself);
+  Tab/Shift+Tab cycle within; Escape or scrim-click dismiss and restore focus to the element that
+  opened the dialog. React Native delegates focus containment to `accessibilityViewIsModal`. `Menu`
+  traps focus similarly while open. `Toast` and `Tooltip` do not trap focus — they are transient /
+  supplementary.
 
 ## ARIA Pattern Reference
 
@@ -49,14 +50,25 @@ they ship.
 | `Button` | Native `<button>` role (or `aria-disabled` on the `asChild` path — see Keyboard Interaction above). Decorative sketch outline is `aria-hidden="true"`. |
 | `Card` | No role by default on React — the caller supplies one. Web Components/React Native automatically expose `role="group"`/`accessibilityRole="summary"` when a `label` is given. |
 | `Input` | `aria-invalid` + `aria-describedby` (pointing at a `role="alert"` error message) on React when `error` is set. Label association via `<label for>`/Radix `Label`. |
+| `Modal` | `role="dialog"` + `aria-modal="true"`, title wired via `aria-labelledby`. React portals to `document.body`; WC uses native `<dialog>` + `::backdrop`; RN uses `accessibilityViewIsModal`. |
+| `Alert` | `role="status"` by default, `role="alert"` for `danger` variant (assertive). Severity-coloured icon with accessible name from the heading text. |
+| `Toast` | `role="status"` (polite) for info/success/warning; `role="alert"` (assertive) for `danger`. Auto-dismiss timer; close button labelled "Dismiss". |
+| `Tooltip` | `role="tooltip"` with the trigger linked via `aria-describedby`. Web: hover (after delay) or focus; dismiss on Escape/blur/leave. RN: tap-to-toggle with `accessibilityHint` on trigger. |
+| `Menu` | `role="menu"` with `role="menuitem"` on items. `aria-activedescendant` (WC) manages active descendant; React uses roving tabindex. Arrow-key navigation, Escape dismiss. |
 
 ## Screen Reader Testing Checklist
 
-- [ ] Every interactive element (`Button`, `Input`) has an accessible name — either visible text,
-  a `label`, or an explicit `aria-label`/`accessibilityLabel`.
+- [ ] Every interactive element has an accessible name — either visible text, a `label`, or an
+  explicit `aria-label`/`accessibilityLabel`. This includes buttons inside `Modal`, `Toast`, and
+  `Alert` (the close/dismiss buttons).
 - [ ] Disabling a component removes it from both the tab order **and** screen reader interaction
   — verify both, since (per Focus Management above) they don't always happen together.
 - [ ] An `Input`'s error message is announced when it appears, not just visually shown.
+  `FormField` automates this with `aria-describedby` pointing at the error's `role="alert"`.
+- [ ] Opening a `Modal` moves focus into the dialog and traps it; closing restores focus to the
+  trigger. This applies to both keyboard (Tab/Shift+Tab) and screen-reader virtual cursor.
+- [ ] `Toast` and `Alert` with `variant="danger"` are announced assertively (`role="alert"`);
+  other severities use a polite `role="status"` that does not interrupt.
 - [ ] Decorative elements (the sketch outline SVGs) are silent — confirm they don't get announced
   or receive focus.
 - [ ] Toggling dark mode doesn't change any of the above (the `[data-theme]` switch is purely

--- a/apps/website/src/pages/patterns.mdx
+++ b/apps/website/src/pages/patterns.mdx
@@ -1,27 +1,46 @@
 ---
 layout: ../layouts/MarkdownLayout.astro
 title: Patterns
-description: Reusable composition patterns for forms, feedback, and more.
+description: Reusable composition patterns for forms, data states, feedback, and page layout.
 ---
 
-Patterns show how to combine multiple components to solve recurring user flows. The items below
-are an IA skeleton — deeper content will be filled in later.
+import { withBase } from '../lib/withBase';
 
-## Form Patterns
+Patterns show how to combine multiple GHDS components to solve recurring user flows. Each pattern
+page covers _when_ to use it, _which_ components to compose, _how_ to handle accessibility, and a
+live demo of the result.
 
-- Placement and spacing of labels, inputs, helper text, and error messages (all using
-  `sys.spacing.*`)
-- Validation and `aria-invalid` / `role="alert"` handling
+## Form & Auth
 
-## Feedback Patterns
+<a href={withBase('/patterns/form-and-auth/')}>Form & Auth Patterns →</a>
 
-- Success/warning/danger state colors (`sys.color.bg.success`, etc.)
-- When to use toasts vs. inline alerts
+Composing `FormField`, `Input`, `Select`, `Checkbox`, `Radio`, `Switch`, and `Button` into
+validated, accessible forms. Covers validation timing, inline vs summary errors, login, signup
+(step-by-step), and password reset flows.
 
-## Layout Patterns
+## Data & Search
 
-- Card grids and responsive tracks
-- Header/body/footer shell composition
+<a href={withBase('/patterns/data-and-search/')}>Data & Search Patterns →</a>
 
-> This page is an information architecture (IA) skeleton stub. Routing and navigation are fully
-> functional.
+Handling the four data states — loading (`Skeleton` / `Spinner`), populated, empty, and error
+(`Alert`) — plus search, filter chips (`Badge`), sorting, and `Table` integration.
+
+## Feedback & Layout
+
+<a href={withBase('/patterns/feedback-and-layout/')}>Feedback & Layout Patterns →</a>
+
+Choosing the right feedback channel — `Toast` vs `Alert` vs `Modal` — with a decision tree and
+severity guide. Plus page shell (header/body/footer), sidebar layout, and responsive breakpoint
+application using `sys.breakpoint.*` tokens.
+
+---
+
+### How Patterns Differ from Components
+
+- **Components** are individual building blocks — a `Button`, a `Modal`, a `Table`. Each has its
+  own page covering anatomy, variants, props, and accessibility.
+- **Patterns** are recipes — they show how to combine several components to solve a real user need.
+  A login form isn't a single component; it's `FormField` + `Input` + `Button` composed with
+  validation logic.
+
+See the <a href={withBase('/components/')}>Components</a> section for the full component catalogue.

--- a/apps/website/src/pages/patterns/data-and-search.mdx
+++ b/apps/website/src/pages/patterns/data-and-search.mdx
@@ -1,0 +1,178 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Data & Search Patterns
+description: Search, filter, sort, and data state patterns — empty, loading, and error — for lists and tables.
+---
+
+import DoDont from '../../components/DoDont.astro';
+import KeyboardTable from '../../components/KeyboardTable.astro';
+import PatternDataDemoReact from '../../components/demos/PatternDataDemo.tsx';
+import PatternDataDemoLit from '../../components/demos/PatternDataDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+## Overview
+
+Every list, table, or data view goes through the same lifecycle: _loading_ → _populated_ (or
+_empty_) → possibly _error_. This pattern covers how to compose `Input`, `Button`, `Table`,
+`Spinner`, `Skeleton`, `Alert`, `Badge`, and `Pagination` to handle all four states with a
+consistent UX — and how to add search, filter, and sort on top.
+
+## The Four Data States
+
+| State | Trigger | Component | Behaviour |
+|-------|---------|-----------|-----------|
+| **Loading** (first paint) | Page / view mounts, data fetch starts | `Skeleton` | Shows the _shape_ of content before it arrives — reduces layout shift and perceived wait |
+| **Loading** (subsequent) | Filter change, pagination, refresh | `Spinner` | Indicates an in-progress action without hiding existing content |
+| **Empty** | Query returned zero results, or no items exist yet | `<div>` + illustration + message + `Button` | A friendly, hand-drawn-style empty state with a clear next action |
+| **Error** | Network failure, server error, permission denied | `Alert variant="danger"` + retry `Button` | Explains what happened and offers a direct path to recovery |
+
+### Skeleton vs Spinner Decision Tree
+
+```
+Is there existing content on screen?
+├── No (first paint) → Skeleton
+└── Yes (refresh / filter) → Spinner
+```
+
+`Skeleton` uses `variant="text"`, `"heading"`, `"avatar"`, or `"block"` to mirror the page's
+layout. A typical data table skeleton renders 5–8 rows of alternating text + block shapes. See
+the <a href={withBase('/components/skeleton/')}>Skeleton</a> component page for variant examples.
+
+### Empty State
+
+A hand-drawn empty state is an opportunity to express GHDS's personality. Pair a sketchy
+illustration with a warm message and a clear action:
+
+```
+  ┌──────────────────────────────────────┐
+  │        (hand-drawn illustration)      │
+  │                                      │
+  │   No search results for "xyz"       │
+  │   Try a different term or clear      │
+  │   the filter.                        │
+  │                                      │
+  │          [ Clear filters ]           │
+  └──────────────────────────────────────┘
+```
+
+```tsx
+// React — empty state
+<Card>
+  <div style={{ textAlign: 'center', padding: 'var(--sys-spacing-xl)' }}>
+    <Icon name="search" size="lg" />
+    <p>No results for "{query}".</p>
+    <Button variant="neutral" onClick={clearSearch}>Clear search</Button>
+  </div>
+</Card>
+```
+
+## Search, Filter & Sort
+
+### Search Bar
+
+A search input paired with a `Button` (icon or text). Debounce the input (300–400ms) before firing
+queries — don't search on every keystroke.
+
+```tsx
+// React — search with debounce
+<Input
+  placeholder="Search items..."
+  value={query}
+  onChange={(e) => setQuery(e.target.value)}
+/>
+```
+
+For Web Components, use `gh-input` with a debounced `input` event listener.
+
+### Filter Chips / Badges
+
+Active filters are displayed as `Badge` components with a dismiss action. A "Clear all" link or
+button resets the filter set. The `Badge` component's sketchy style integrates naturally.
+
+```tsx
+// React — filter chips
+{filters.map((f) => (
+  <Badge key={f} variant="neutral" onDismiss={() => removeFilter(f)}>
+    {f}
+  </Badge>
+))}
+```
+
+### Sorting
+
+Column headers in `Table` are clickable to toggle ascending / descending sort. The `Table` component
+accepts a `sort` prop (`{ column, direction }`) and calls `onSort` on header click. A sorted column
+shows an arrow indicator (`↑` / `↓`).
+
+### Search + Filter + Sort Together
+
+```
+┌──────────────────────────────────────────────────────┐
+│  [ 🔍 Search input...           ]  [ Sort by: Name ▾ ] │
+│  [ ✕ Electronics ] [ ✕ In stock ]  [ Clear all ]     │
+├──────────────────────────────────────────────────────┤
+│  Name              │ Price  │ Status                  │
+│  ──────────────────┼────────┼─────────────────────────│
+│  Wireless Mouse    │ $29.99 │ In stock                │
+│  USB-C Hub         │ $49.99 │ Low stock               │
+│  ──────────────────┴────────┴─────────────────────────│
+│           ← 1  2  3  4  5 →                           │
+└──────────────────────────────────────────────────────┘
+```
+
+## Live Demo
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <PatternDataDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <PatternDataDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native — data states
+import { Alert, Button, Skeleton, Spinner, Table } from '@ghds/react-native';
+
+// Loading
+<Skeleton variant="block" />;
+
+// Error
+<Alert variant="danger" title="Failed to load">
+  Check your connection. <Button label="Retry" onPress={refetch} />
+</Alert>;
+
+// Empty
+<Text>No items yet. <Button label="Add one" variant="neutral" /></Text>;
+```
+
+## Accessibility
+
+<KeyboardTable
+  rows={[
+    { keys: 'Tab', action: 'Move between search input, filter chips, table headers, and pagination.' },
+    { keys: 'Enter / Space', action: 'Toggle a sortable column header; activate a pagination button; dismiss a filter chip.' },
+  ]}
+/>
+
+- **Live region for results**: wrap the result count in a `role="status"` (polite) element.
+  "Showing 12 of 45 items" updates are announced without interrupting.
+- **Error announcement**: `Alert variant="danger"` uses `role="alert"` — assertive, so the error
+  message is read immediately.
+- **Loading announcements**: a `Spinner` alone is not sufficient for screen readers — pair it with
+  visually-hidden text like "Loading results" that updates when loading completes.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a>.
+
+## Related Components
+
+- <a href={withBase('/components/table/')}>Table</a> — sortable, selectable data display
+- <a href={withBase('/components/input/')}>Input</a> — search field
+- <a href={withBase('/components/badge/')}>Badge</a> — filter chips
+- <a href={withBase('/components/spinner/')}>Spinner</a> / <a href={withBase('/components/skeleton/')}>Skeleton</a> — loading states
+- <a href={withBase('/components/alert/')}>Alert</a> — error state
+- <a href={withBase('/components/pagination/')}>Pagination</a> — page navigation
+- <a href={withBase('/components/card/')}>Card</a> — empty state container
+- <a href={withBase('/components/icon/')}>Icon</a> — empty state illustration

--- a/apps/website/src/pages/patterns/feedback-and-layout.mdx
+++ b/apps/website/src/pages/patterns/feedback-and-layout.mdx
@@ -1,0 +1,222 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Feedback & Layout Patterns
+description: When to use toast, alert, or modal — plus page shell, sidebar, and responsive layout with GHDS.
+---
+
+import DoDont from '../../components/DoDont.astro';
+import KeyboardTable from '../../components/KeyboardTable.astro';
+import PatternFeedbackDemoReact from '../../components/demos/PatternFeedbackDemo.tsx';
+import PatternFeedbackDemoLit from '../../components/demos/PatternFeedbackDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+## Overview
+
+Feedback is how an app tells the user what just happened — a save succeeded, a request failed, or
+something needs attention. This pattern covers how to choose the right feedback channel (Toast,
+Alert, Modal) and how to compose a page shell — header, body, footer, sidebar — that responds to
+the viewport.
+
+## Feedback Channel Decision Tree
+
+Choosing the right feedback component is the most frequent pattern decision in any app. Use this
+tree:
+
+```
+Did the user initiate the action?
+├── Yes (they clicked "Save", "Delete", "Submit")
+│   └── Is the result still visible on screen?
+│       ├── Yes → Alert (inline, persistent)
+│       └── No (navigated away / async completion) → Toast
+│
+└── No (system event, websocket, background sync)
+    └── Does this require a user decision?
+        ├── Yes → Modal (interrupting, requires action)
+        └── No → Toast (informational, auto-dismiss)
+```
+
+### Component Comparison
+
+| | Toast | Alert | Modal |
+|---|---|---|---|
+| **Position** | Fixed, bottom-right | Inline, in layout | Centred overlay with scrim |
+| **Persistence** | Auto-dismiss (default 5s) | Stays until dismissed | Stays until explicit close |
+| **Interrupts** | No (polite, except danger) | No (polite, except danger) | Yes (traps focus, locks scroll) |
+| **Requires action** | No | Optional dismiss button | Yes (at minimum "OK" / "Cancel") |
+| **Use for** | "Saved", "Copied", "Message sent" | Form errors, status banners, warnings | Confirmations, detail views, short forms |
+| **Stacking** | Multiple can stack | One per context | One at a time (never nested) |
+
+### State Colours
+
+All feedback components use the same severity palette from `sys.color.bg.*`:
+
+| Severity | Token prefix | Icon | When |
+|----------|-------------|------|------|
+| **Info** | `*.info` | ℹ️ info | Neutral status, contextual hints |
+| **Success** | `*.success` | ✓ check | Task completed, data saved |
+| **Warning** | `*.warning` | ⚠ warning | Non-blocking issue, attention needed |
+| **Danger** | `*.danger` | ⚠ warning | Error, destructive action, failure |
+
+<DoDont
+  do={[
+    'Use Toast for transient confirmations (save, copy, send) — they auto-dismiss so the user is not blocked.',
+    'Use Alert for inline status that needs to persist (form errors, connection status, maintenance notice).',
+    'Use Modal for interrupting decisions (delete confirmation, sign-out prompt, critical error).',
+    "Match the severity to the outcome: success for saves, danger for failures, warning for cautions.",
+  ]}
+  dont={[
+    "Don't use a Modal for a simple success message — it's too heavy.",
+    "Don't stack multiple Modals — it disorients users and creates focus-management issues.",
+    "Don't use Toast for errors that require user action — they disappear before the user can act.",
+    "Don't rely on colour alone to communicate severity — always include an icon and text.",
+  ]}
+/>
+
+## Page Shell
+
+A page shell is the persistent chrome around content: header, sidebar (optional), body, and footer.
+GHDS does not ship a dedicated shell component — instead, compose it from existing components and
+tokens.
+
+### Header / Body / Footer
+
+```
+┌─────────────────────────────────────────────────────┐
+│  Header (Breadcrumb + heading + actions)            │  ← sys.spacing.lg padding
+├─────────────────────────────────────────────────────┤
+│                                                     │
+│  Body (Card / Table / Form — the main content)      │  ← flex: 1; overflow: auto
+│                                                     │
+├─────────────────────────────────────────────────────┤
+│  Footer (Pagination / legal / secondary links)      │  ← sys.spacing.md padding
+└─────────────────────────────────────────────────────┘
+```
+
+```tsx
+// React — page shell
+<div style={{ display: 'flex', flexDirection: 'column', minHeight: '100vh' }}>
+  <header style={{ padding: 'var(--sys-spacing-lg)' }}>
+    <Breadcrumb items={breadcrumbs} />
+    <h1>Page Title</h1>
+  </header>
+  <main style={{ flex: 1, padding: '0 var(--sys-spacing-lg)' }}>
+    {children}
+  </main>
+  <footer style={{ padding: 'var(--sys-spacing-md) var(--sys-spacing-lg)' }}>
+    <Pagination current={page} total={totalPages} onChange={setPage} />
+  </footer>
+</div>
+```
+
+### Sidebar Layout
+
+A two-column layout with a fixed-width sidebar (`Card` or `Menu`) and a fluid body. Use
+`sys.breakpoint.tablet` to collapse the sidebar into a drawer or `Tabs` on mobile.
+
+```
+┌──────────┬──────────────────────────────────────────┐
+│ Sidebar  │  Body (fluid)                             │
+│ (240px)  │                                           │
+│          │                                           │
+│ Menu     │  Main content area                        │
+│ items    │                                           │
+│          │                                           │
+└──────────┴──────────────────────────────────────────┘
+```
+
+```tsx
+// React — sidebar layout
+<div style={{ display: 'flex', gap: 'var(--sys-spacing-lg)' }}>
+  <aside style={{ width: 240, flexShrink: 0 }}>
+    <Card>
+      <Menu items={navItems} />
+    </Card>
+  </aside>
+  <main style={{ flex: 1, minWidth: 0 }}>{children}</main>
+</div>
+```
+
+## Responsive Breakpoints
+
+Apply the breakpoints defined in `sys.breakpoint.*` (M8 Foundations) to reflow layouts:
+
+| Breakpoint | Value | Typical Adaptation |
+|------------|-------|-------------------|
+| `mobile` | 0px (default) | Single column, stacked |
+| `tablet` | 768px | Two columns, sidebar appears |
+| `desktop` | 1024px | Full layout, sidebar visible |
+| `wide` | 1440px | Max-width content container |
+
+```css
+/* Mobile-first: single column by default */
+.page { display: flex; flex-direction: column; }
+
+/* Tablet+: sidebar visible */
+@media (min-width: 768px) {
+  .page { flex-direction: row; }
+  .sidebar { display: block; width: 240px; }
+}
+```
+
+React Native has no `@media` queries — use `useWindowDimensions()` and compare `width` against the
+same breakpoint values from `@ghds/tokens`.
+
+## Live Demo
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <PatternFeedbackDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <PatternFeedbackDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native — feedback
+import { Alert, Button, Modal, Toast } from '@ghds/react-native';
+
+// Transient success
+<Toast open={saved} onClose={() => setSaved(false)} variant="success" title="Saved" />;
+
+// Inline warning
+<Alert variant="warning" title="Session expiring">Save your work soon.</Alert>;
+
+// Interrupting confirmation
+<Modal open={confirming} onClose={() => setConfirming(false)} title="Delete item?">
+  <Text>This cannot be undone.</Text>
+  <Button label="Delete" variant="danger" onPress={handleDelete} />
+</Modal>;
+```
+
+## Accessibility
+
+<KeyboardTable
+  rows={[
+    { keys: 'Escape', action: 'Dismiss an open Modal, Toast (close button), or Tooltip.' },
+    { keys: 'Tab', action: 'Move between sidebar items, then into the body.' },
+    { keys: 'Enter / Space', action: 'Activate a sidebar navigation item.' },
+  ]}
+/>
+
+- **Toast announcements**: info/success/warning use `role="status"` (polite — does not interrupt);
+  danger uses `role="alert"` (assertive — interrupts immediately).
+- **Modal focus**: focus is trapped inside while open and restored to the trigger on close. See
+  the <a href={withBase('/components/modal/#accessibility')}>Modal accessibility section</a>.
+- **Skip links**: in a page shell with a sidebar, provide a "Skip to content" link as the first
+  focusable element so keyboard users can bypass navigation.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a>.
+
+## Related Components
+
+- <a href={withBase('/components/toast/')}>Toast</a> — transient notification
+- <a href={withBase('/components/alert/')}>Alert</a> — inline status banner
+- <a href={withBase('/components/modal/')}>Modal</a> — interrupting dialog
+- <a href={withBase('/components/tooltip/')}>Tooltip</a> — supplementary hint
+- <a href={withBase('/components/breadcrumb/')}>Breadcrumb</a> — header navigation
+- <a href={withBase('/components/pagination/')}>Pagination</a> — footer navigation
+- <a href={withBase('/components/menu/')}>Menu</a> — sidebar navigation
+- <a href={withBase('/components/card/')}>Card</a> — sidebar / content container
+- <a href={withBase('/foundations/')}>Foundations</a> — breakpoint, grid, and spacing tokens

--- a/apps/website/src/pages/patterns/form-and-auth.mdx
+++ b/apps/website/src/pages/patterns/form-and-auth.mdx
@@ -1,0 +1,186 @@
+---
+layout: ../../layouts/MarkdownLayout.astro
+title: Form & Auth Patterns
+description: How to compose form fields, validation, and authentication flows with GHDS components.
+---
+
+import DoDont from '../../components/DoDont.astro';
+import KeyboardTable from '../../components/KeyboardTable.astro';
+import PatternFormDemoReact from '../../components/demos/PatternFormDemo.tsx';
+import PatternFormDemoLit from '../../components/demos/PatternFormDemo.astro';
+import { withBase } from '../../lib/withBase';
+
+## Overview
+
+Forms are the primary way users give data to an application. This pattern covers composing
+`FormField`, `Input`, `Textarea`, `Select`, `Checkbox`, `Radio`, `Switch`, and `Button` into
+validated, accessible forms — plus the authentication flows (login, signup, password reset) that
+form the entry point to most apps.
+
+## Form Layout Composition
+
+A well-structured form layers three kinds of information per field, all spaced via `sys.spacing.*`:
+
+```
+┌─ FormField ──────────────────────────────┐
+│  Label (required/optional marker)         │  ← comp.formField.label.*
+│  ┌─ Input / Select / Textarea ──────────┐ │
+│  │                                      │ │  ← comp.formField.input.*
+│  └──────────────────────────────────────┘ │
+│  Helper text (contextual, optional)       │  ← comp.formField.helper.*
+│  Error message (role="alert", conditional)│  ← comp.formField.error.*
+└───────────────────────────────────────────┘
+```
+
+`FormField` automates the wiring: it links the label via `htmlFor` / `for`, and connects error
+messages to inputs using `aria-describedby` + `aria-invalid`, so assistive technology announces
+errors as they appear.
+
+### Spacing
+
+Every gap between fields, labels, and messages is sourced from `sys.spacing.*`. The
+`comp.formField.gap` token controls the vertical rhythm between stacked `FormField` instances;
+internal label→input→helper→error gaps are also token-driven.
+
+```css
+/* Stack form fields */
+.form { display: flex; flex-direction: column; gap: var(--comp-formField-gap); }
+```
+
+## Validation
+
+### When to Validate
+
+<DoDont
+  do={[
+    'Validate on blur (per-field) — let the user finish typing first.',
+    'Validate on submit (whole-form) — catch everything at once before the request.',
+    'Announce errors assertively with role="alert" so screen readers interrupt.',
+    'Mark required fields with an asterisk or "(required)" text — not colour alone.',
+  ]}
+  dont={[
+    "Don't validate on every keystroke — it's noisy and punishes fast typists.",
+    "Don't clear errors until the field is re-focused or re-submitted.",
+    "Don't use placeholder text as a label — it disappears on focus.",
+  ]}
+/>
+
+### Inline vs Summary Errors
+
+| Strategy | When to use | Implementation |
+|----------|-------------|----------------|
+| **Inline (per-field)** | Short forms (≤ 5 fields), or when the error is tightly coupled to one field | `FormField error="..."` |
+| **Summary (top of form)** | Long forms (≥ 6 fields), or when one decision affects multiple fields | Render an `Alert variant="danger"` above the form summarising all errors, plus inline indicators |
+
+For summary errors, pair a top-level `Alert` with per-field `aria-invalid="true"` markers — the
+summary announces the error count, and each field shows a visual indicator.
+
+```tsx
+// React — summary + inline pattern
+{errors.length > 0 && (
+  <Alert variant="danger" title={`${errors.length} field(s) need attention`}>
+    <ul style={{ margin: 0, paddingLeft: '1.25rem' }}>
+      {errors.map((e) => <li key={e.field}>{e.message}</li>)}
+    </ul>
+  </Alert>
+)}
+<FormField label="Email" error={fieldErrors.email}>
+  <Input aria-invalid={!!fieldErrors.email} />
+</FormField>
+```
+
+## Authentication Flows
+
+### Login
+
+A minimal two-field form (`FormField` + `Input` for email/password, `Button variant="primary"` to
+submit). A "Forgot password?" link navigates to the reset flow. Failed login shows an inline error
+or a top-of-form `Alert variant="danger"`.
+
+```tsx
+// React — login form
+<FormField label="Email">
+  <Input type="email" placeholder="you@example.com" />
+</FormField>
+<FormField label="Password">
+  <Input type="password" />
+</FormField>
+<Button variant="primary">Log in</Button>
+```
+
+### Signup (Step-by-Step)
+
+Multi-step signup uses `Tabs` (or sequential panels) to split the form into manageable chunks.
+Each step has its own validation; the "Next" button only enables when the current step is valid.
+A `Progress` bar or step indicator shows position.
+
+```tsx
+// React — 3-step signup with Tabs
+const [step, setStep] = useState(0);
+<Tabs activeTab={step} onChange={setStep} items={[
+  { label: 'Account', content: <AccountStep /> },
+  { label: 'Profile', content: <ProfileStep /> },
+  { label: 'Confirm', content: <ConfirmStep /> },
+]} />;
+```
+
+### Password Reset
+
+Two screens: (1) enter email → `Button` submits → `Toast variant="success"` ("Check your inbox");
+(2) enter new password + confirm → `Button` submits → redirect to login. On error, `Alert
+variant="danger"` with a retry prompt.
+
+## Live Demo
+
+<div class="demo-columns">
+  <div class="demo-column">
+    <h3>React <span class="demo-tag">@ghds/react</span></h3>
+    <PatternFormDemoReact client:only="react" />
+  </div>
+  <div class="demo-column">
+    <h3>Web Components <span class="demo-tag">@ghds/web-components</span></h3>
+    <PatternFormDemoLit />
+  </div>
+</div>
+
+```tsx
+// React Native — login form
+import { Button, FormField, Input } from '@ghds/react-native';
+
+<FormField label="Email">
+  <Input placeholder="you@example.com" />
+</FormField>
+<FormField label="Password">
+  <Input secureTextEntry />
+</FormField>
+<Button label="Log in" variant="primary" onPress={handleLogin} />
+```
+
+## Accessibility
+
+<KeyboardTable
+  rows={[
+    { keys: 'Tab', action: 'Move between form fields in document order.' },
+    { keys: 'Enter', action: 'Submit the form (when focus is in a field).' },
+    { keys: 'Space', action: 'Toggle Checkbox / Switch; activate Button.' },
+  ]}
+/>
+
+- **Error announcement**: `FormField` wires `aria-describedby` to the error, and the error element
+  has `role="alert"` so it interrupts screen readers.
+- **Required fields**: Mark with text ("required") rather than only colour. `FormField` accepts a
+  `required` prop that appends an asterisk — visually and for screen readers.
+- **Disabled buttons**: A disabled submit button communicates "form not ready" — pair it with
+  visible hints about which fields need attention.
+- See the <a href={withBase('/accessibility/')}>Accessibility Guide</a> for full keyboard and ARIA
+  reference.
+
+## Related Components
+
+- <a href={withBase('/components/form-field/')}>FormField</a> — the label + helper + error wrapper
+- <a href={withBase('/components/input/')}>Input</a> / <a href={withBase('/components/textarea/')}>Textarea</a> — text entry
+- <a href={withBase('/components/select/')}>Select</a> — dropdown selection
+- <a href={withBase('/components/checkbox/')}>Checkbox</a> / <a href={withBase('/components/radio/')}>Radio</a> / <a href={withBase('/components/switch/')}>Switch</a> — choice controls
+- <a href={withBase('/components/button/')}>Button</a> — submit and action
+- <a href={withBase('/components/alert/')}>Alert</a> / <a href={withBase('/components/toast/')}>Toast</a> — feedback
+- <a href={withBase('/components/tabs/')}>Tabs</a> / <a href={withBase('/components/progress/')}>Progress</a> — multi-step signup


### PR DESCRIPTION
## Summary

Completes the remaining work for M11 (accessibility guide updates) and the full M12 pattern library milestone.

### M11 — Accessibility Guide (GHD-35)
- Updated `accessibility.mdx` Keyboard Interaction, Focus Management, ARIA Pattern Reference, and Screen Reader Checklist to reflect all M10–M11 components (Modal, Toast, Alert, Tooltip, Menu)
- Removed stale "don't exist yet" / "no component implements" references from the M11-open era

### M12 — Pattern Library (GHD-37/38/39)
- **Form & Auth** (`patterns/form-and-auth.mdx`): form layout, validation, inline vs summary errors, login, signup, password reset + React & Lit demos
- **Data & Search** (`patterns/data-and-search.mdx`): loading/empty/error states, Skeleton vs Spinner decision tree, search bar, filter chips (Badge), sorting + demos
- **Feedback & Layout** (`patterns/feedback-and-layout.mdx`): Toast vs Alert vs Modal decision tree, severity palette, page shell, sidebar, responsive breakpoints + demos
- `patterns.mdx` rewritten as overview page

### Verification
- `pnpm build --filter @ghds/website` passes (38 pages built)
- All demo components render React + Lit client islands

Closes GHD-35
Closes GHD-37
Closes GHD-38
Closes GHD-39