### PR TITLE
feat(tokens): Penpot token sync script (GHD-42)

### DIFF
--- a/packages/tokens/package.json
+++ b/packages/tokens/package.json
@@ -43,6 +43,7 @@
   ],
   "scripts": {
     "build": "node style-dictionary.config.js",
+    "penpot:tokens": "node scripts/build-penpot-tokens.mjs",
     "test": "vitest run",
     "test:watch": "vitest",
     "lint": "biome check .",

--- a/packages/tokens/scripts/build-penpot-tokens.mjs
+++ b/packages/tokens/scripts/build-penpot-tokens.mjs
@@ -40,9 +40,15 @@ const jsonFiles = (subdir) =>
     .sort()
     .map((f) => join(SRC, subdir, f));
 
+// Skip keys that would walk the prototype chain — token files are trusted
+// local source, but a stray `__proto__`/`constructor`/`prototype` key must
+// never reach `target[k] = …` (CodeQL: prototype-polluting function).
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+
 /** Deep-merge plain objects (used to fold many tier files into one tree). */
 function deepMerge(target, source) {
   for (const [k, v] of Object.entries(source)) {
+    if (UNSAFE_KEYS.has(k)) continue;
     if (v && typeof v === 'object' && !Array.isArray(v) && !('$value' in v)) {
       target[k] = deepMerge(target[k] && typeof target[k] === 'object' ? target[k] : {}, v);
     } else {
@@ -90,7 +96,7 @@ function normalize(node, inheritedType, stats) {
   const out = {};
   if (node.$description !== undefined) out.$description = node.$description;
   for (const [k, v] of Object.entries(node)) {
-    if (k === '$type' || k === '$description') continue;
+    if (k === '$type' || k === '$description' || UNSAFE_KEYS.has(k)) continue;
     if (v && typeof v === 'object' && !Array.isArray(v)) {
       out[k] = normalize(v, ownType, stats);
     }

--- a/packages/tokens/scripts/build-penpot-tokens.mjs
+++ b/packages/tokens/scripts/build-penpot-tokens.mjs
@@ -1,0 +1,176 @@
+// build-penpot-tokens.mjs
+//
+// Emit a Penpot-importable design-token bundle from the DTCG source
+// (`src/**/*.json`), NOT from the resolved `dist/json` output.
+//
+// Why source, not dist:
+//   - dist/json has aliases already resolved to literal values; Penpot would
+//     then store flat values with no `{ref…}` reference chain. We want Penpot
+//     to hold the 3-tier reference graph so a token edit cascades the same way
+//     it does in code.
+//
+// Output format: the Tokens Studio multi-set dialect that Penpot imports —
+//   { <setName>: <tokenTree>, …, "$themes": [...], "$metadata": {...} }
+// Sets map to the tier files; a Light/Dark theme toggles the two `sys.color`
+// sets. See M14 Phase B (GHD-42).
+//
+// Normalization: GHDS source leans on DTCG group-level `$type` inheritance
+// (e.g. `ref.palette.$type = "color"` applies to every ramp step). Not every
+// DTCG consumer honours inheritance, so we propagate `$type` down onto every
+// leaf token and drop the now-redundant group markers. `$value` (and therefore
+// every `{alias}` reference) is never touched.
+
+import { mkdirSync, readdirSync, readFileSync, writeFileSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const __dirname = dirname(fileURLToPath(import.meta.url));
+const PKG = join(__dirname, '..');
+const SRC = join(PKG, 'src');
+const OUT_DIR = join(PKG, 'dist', 'penpot');
+const OUT_FILE = join(OUT_DIR, 'penpot.tokens.json');
+
+/** Read + parse one JSON file. */
+const readJson = (p) => JSON.parse(readFileSync(p, 'utf8'));
+
+/** List `*.json` files in a src subdirectory, sorted for deterministic output. */
+const jsonFiles = (subdir) =>
+  readdirSync(join(SRC, subdir))
+    .filter((f) => f.endsWith('.json'))
+    .sort()
+    .map((f) => join(SRC, subdir, f));
+
+/** Deep-merge plain objects (used to fold many tier files into one tree). */
+function deepMerge(target, source) {
+  for (const [k, v] of Object.entries(source)) {
+    if (v && typeof v === 'object' && !Array.isArray(v) && !('$value' in v)) {
+      target[k] = deepMerge(target[k] && typeof target[k] === 'object' ? target[k] : {}, v);
+    } else {
+      target[k] = v;
+    }
+  }
+  return target;
+}
+
+/** Merge every file in a subdir into a single token tree. */
+function mergeDir(subdir) {
+  return jsonFiles(subdir).reduce((acc, p) => deepMerge(acc, readJson(p)), {});
+}
+
+const isToken = (node) => node && typeof node === 'object' && Object.hasOwn(node, '$value');
+
+/**
+ * Return a copy of `node` where every leaf token carries an explicit `$type`
+ * (inherited from the nearest ancestor when absent) and group-level `$type`
+ * markers are removed. `$value` is copied verbatim — aliases stay as `{…}`.
+ * `stats` accumulates metrics for the validation summary.
+ */
+function normalize(node, inheritedType, stats) {
+  const ownType = node.$type ?? inheritedType;
+
+  if (isToken(node)) {
+    stats.tokens += 1;
+    const out = {};
+    // $type first for readability
+    const resolvedType = node.$type ?? inheritedType;
+    if (resolvedType !== undefined) {
+      out.$type = resolvedType;
+      stats.typed += 1;
+      if (node.$type === undefined) stats.stampedFromGroup += 1;
+    }
+    out.$value = node.$value;
+    if (typeof node.$value === 'string' && node.$value.includes('{')) {
+      stats.aliases += 1;
+    }
+    if (node.$description !== undefined) out.$description = node.$description;
+    return out;
+  }
+
+  // Group node: recurse, drop its own $type (now carried by the leaves).
+  const out = {};
+  if (node.$description !== undefined) out.$description = node.$description;
+  for (const [k, v] of Object.entries(node)) {
+    if (k === '$type' || k === '$description') continue;
+    if (v && typeof v === 'object' && !Array.isArray(v)) {
+      out[k] = normalize(v, ownType, stats);
+    }
+  }
+  return out;
+}
+
+// Order matters for Tokens Studio: later sets override earlier ones on the
+// same token path. The two `sys.color.*` sets share paths but are never both
+// enabled, so no real collision occurs.
+export const tokenSetOrder = ['ref', 'sys', 'sys.color.light', 'sys.color.dark', 'comp'];
+
+const baseSets = { ref: 'enabled', sys: 'enabled', comp: 'enabled' };
+export const themes = [
+  {
+    id: 'ghds-theme-light',
+    name: 'Light',
+    group: 'Color scheme',
+    selectedTokenSets: {
+      ...baseSets,
+      'sys.color.light': 'enabled',
+      'sys.color.dark': 'disabled',
+    },
+  },
+  {
+    id: 'ghds-theme-dark',
+    name: 'Dark',
+    group: 'Color scheme',
+    selectedTokenSets: {
+      ...baseSets,
+      'sys.color.light': 'disabled',
+      'sys.color.dark': 'enabled',
+    },
+  },
+];
+
+/**
+ * Build the Penpot import bundle from `src/**`. Pure: reads source files,
+ * returns `{ bundle, stats }`, writes nothing. The CLI wrapper below handles
+ * output; tests call this directly.
+ */
+export function buildBundle() {
+  const stats = { tokens: 0, aliases: 0, typed: 0, stampedFromGroup: 0 };
+  const sets = {
+    ref: normalize(mergeDir('ref'), undefined, stats),
+    sys: normalize(readJson(join(SRC, 'sys', '_shared.json')), undefined, stats),
+    'sys.color.light': normalize(readJson(join(SRC, 'sys', 'light.json')), undefined, stats),
+    'sys.color.dark': normalize(readJson(join(SRC, 'sys', 'dark.json')), undefined, stats),
+    comp: normalize(mergeDir('comp'), undefined, stats),
+  };
+  const bundle = { ...sets, $themes: themes, $metadata: { tokenSetOrder } };
+  return { bundle, stats };
+}
+
+/** Write the bundle to `dist/penpot/` and print a validation summary. */
+function main() {
+  const { bundle, stats } = buildBundle();
+  mkdirSync(OUT_DIR, { recursive: true });
+  writeFileSync(OUT_FILE, `${JSON.stringify(bundle, null, 2)}\n`, 'utf8');
+
+  const rel = OUT_FILE.replace(`${PKG}/`, '');
+  console.log(`penpot:tokens → ${rel}`);
+  console.log(
+    `  sets: ${tokenSetOrder.join(', ')}  |  themes: ${themes.map((t) => t.name).join(', ')}`,
+  );
+  console.log(
+    `  tokens: ${stats.tokens}  aliases preserved: ${stats.aliases}  ` +
+      `typed leaves: ${stats.typed} (of which ${stats.stampedFromGroup} inherited from a group)`,
+  );
+
+  if (stats.typed !== stats.tokens) {
+    console.error(
+      `  ⚠ ${stats.tokens - stats.typed} token(s) have no resolvable $type — check the source tiers.`,
+    );
+    process.exitCode = 1;
+  }
+}
+
+// Run only when invoked directly (`node scripts/build-penpot-tokens.mjs`),
+// not when imported by the test suite.
+if (process.argv[1] && fileURLToPath(import.meta.url) === process.argv[1]) {
+  main();
+}

--- a/packages/tokens/test/penpot-tokens.test.ts
+++ b/packages/tokens/test/penpot-tokens.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it } from 'vitest';
+// @ts-expect-error — plain-JS build script, no type declarations
+import { buildBundle, themes, tokenSetOrder } from '../scripts/build-penpot-tokens.mjs';
+
+// Guards the GHD-42 acceptance criteria for the Penpot import bundle:
+// it parses, every `{alias}` reference is preserved (never resolved to a
+// literal), every leaf carries an explicit `$type`, and the ref→sys→comp
+// reference graph resolves within each theme.
+
+interface Leaf {
+  $type?: string;
+  $value: unknown;
+}
+
+function isLeaf(node: unknown): node is Leaf {
+  return typeof node === 'object' && node !== null && '$value' in node;
+}
+
+function collect(node: unknown, prefix: string, out: Map<string, Leaf>): void {
+  if (isLeaf(node)) {
+    out.set(prefix, node);
+    return;
+  }
+  if (typeof node !== 'object' || node === null) {
+    return;
+  }
+  for (const [key, child] of Object.entries(node)) {
+    if (key.startsWith('$')) {
+      continue;
+    }
+    collect(child, prefix ? `${prefix}.${key}` : key, out);
+  }
+}
+
+const WHOLE_ALIAS = /^\{([^}]+)\}$/;
+
+const { bundle, stats } = buildBundle();
+
+/** Leaves of one set, keyed by dot-path (path already carries the tier prefix). */
+function leavesOf(setName: string): Map<string, Leaf> {
+  const map = new Map<string, Leaf>();
+  collect((bundle as Record<string, unknown>)[setName], '', map);
+  return map;
+}
+
+describe('penpot token bundle: shape', () => {
+  it('exposes the five tier sets plus $themes and $metadata', () => {
+    expect(Object.keys(bundle).sort()).toEqual(
+      ['$metadata', '$themes', 'comp', 'ref', 'sys', 'sys.color.dark', 'sys.color.light'].sort(),
+    );
+  });
+
+  it('orders sets so sys.color.* overrides never collide with the base sys set', () => {
+    expect(bundle.$metadata.tokenSetOrder).toEqual(tokenSetOrder);
+  });
+
+  it('ships Light and Dark themes that each enable exactly one sys.color set', () => {
+    expect(themes.map((t) => t.name)).toEqual(['Light', 'Dark']);
+    for (const theme of bundle.$themes) {
+      const sets = theme.selectedTokenSets;
+      expect(sets['sys.color.light'] === 'enabled').not.toBe(sets['sys.color.dark'] === 'enabled');
+    }
+  });
+});
+
+describe('penpot token bundle: preservation', () => {
+  it('keeps every alias as an unresolved {reference}', () => {
+    // A resolved bundle would contain literal hex/px values where aliases were.
+    let aliasCount = 0;
+    for (const setName of tokenSetOrder) {
+      for (const leaf of leavesOf(setName).values()) {
+        if (typeof leaf.$value === 'string' && leaf.$value.includes('{')) {
+          expect(leaf.$value).toMatch(WHOLE_ALIAS);
+          aliasCount += 1;
+        }
+      }
+    }
+    expect(aliasCount).toBe(stats.aliases);
+    expect(aliasCount).toBeGreaterThan(0);
+  });
+
+  it('stamps an explicit $type on every leaf token', () => {
+    for (const setName of tokenSetOrder) {
+      for (const [path, leaf] of leavesOf(setName)) {
+        expect(leaf.$type, `${setName} → ${path}`).toBeTypeOf('string');
+      }
+    }
+    expect(stats.typed).toBe(stats.tokens);
+  });
+
+  it('preserves non-string primitive values (e.g. numeric 0)', () => {
+    const ref = leavesOf('ref');
+    expect(ref.get('ref.sketch.roughness.none')?.$value).toBe(0);
+    expect(ref.get('ref.sketch.roughness.none')?.$type).toBe('number');
+  });
+});
+
+describe('penpot token bundle: reference integrity', () => {
+  for (const theme of themes) {
+    it(`resolves every alias within the ${theme.name} theme`, () => {
+      const enabled = Object.entries(theme.selectedTokenSets)
+        .filter(([, state]) => state === 'enabled')
+        .map(([name]) => name);
+
+      const all = new Map<string, Leaf>();
+      for (const setName of enabled) {
+        for (const [path, leaf] of leavesOf(setName)) {
+          all.set(path, leaf);
+        }
+      }
+
+      const dangling: string[] = [];
+      for (const setName of enabled) {
+        for (const [path, leaf] of leavesOf(setName)) {
+          if (typeof leaf.$value !== 'string') {
+            continue;
+          }
+          const match = leaf.$value.match(WHOLE_ALIAS);
+          if (match && !all.has(match[1])) {
+            dangling.push(`${path} → {${match[1]}}`);
+          }
+        }
+      }
+      expect(dangling).toEqual([]);
+    });
+  }
+
+  it('respects tier boundaries: comp→sys and sys→ref only', () => {
+    const violations: string[] = [];
+    for (const [path, leaf] of leavesOf('comp')) {
+      if (typeof leaf.$value === 'string') {
+        const match = leaf.$value.match(WHOLE_ALIAS);
+        if (match && !match[1].startsWith('sys.')) {
+          violations.push(`comp ${path} → ${match[1]}`);
+        }
+      }
+    }
+    for (const setName of ['sys', 'sys.color.light', 'sys.color.dark']) {
+      for (const [path, leaf] of leavesOf(setName)) {
+        if (typeof leaf.$value === 'string') {
+          const match = leaf.$value.match(WHOLE_ALIAS);
+          if (match && !match[1].startsWith('ref.')) {
+            violations.push(`${setName} ${path} → ${match[1]}`);
+          }
+        }
+      }
+    }
+    expect(violations).toEqual([]);
+  });
+});


### PR DESCRIPTION
## What & why

M14 **Phase B** (GHD-42). Emits a Penpot-importable design-token bundle from the DTCG source so a self-hosted Penpot instance can hold GHDS tokens as a live, editable reference graph.

Built from `src/**` (**not** `dist/json`) on purpose: the resolved dist has aliases flattened to literal hex/px, which would give Penpot dead values. Building from source keeps the `ref → sys → comp` reference chain so a token edit cascades the same way it does in code (code stays the source of truth; this is a one-way export).

## How it maps

| GHDS source | Penpot (Tokens Studio dialect) |
| --- | --- |
| `src/ref/*` | set `ref` |
| `src/sys/_shared.json` (theme-invariant) | set `sys` |
| `src/sys/light.json` / `dark.json` (only `sys.color` varies) | sets `sys.color.light` / `sys.color.dark` |
| `src/comp/*` | set `comp` |
| light/dark | `$themes` **Light** / **Dark**, each enabling exactly one `sys.color` set |

`$metadata.tokenSetOrder` fixes precedence; the two `sys.color` sets share paths but are never both enabled, so no collision.

### Normalization (the DTCG-dialect risk GHD-42 flagged)
GHDS source leans on DTCG **group-level `$type` inheritance** (e.g. `ref.palette.$type = "color"` covers every ramp step). Not every consumer honours inheritance, so the script propagates `$type` onto every **leaf** token and drops the now-redundant group markers. `$value` — and therefore every `{alias}` — is copied verbatim; nothing is resolved.

## Validation

`test/penpot-tokens.test.ts` guards the acceptance criteria (9 tests):
- bundle shape (5 sets + `$themes` + `$metadata`)
- **every alias stays an unresolved `{reference}`**
- **explicit `$type` on every leaf**
- per-theme **reference integrity — 0 dangling** (938 refs across Light+Dark)
- tier boundaries: `comp → sys`, `sys → ref`

Build output: **657 tokens, 505 aliases preserved**. Full suite: **107 tests pass**; `biome check` clean.

Run it:
```bash
pnpm --filter @ghds/tokens penpot:tokens   # → dist/penpot/penpot.tokens.json
```

## Scope / notes
- **No changeset**: `scripts/` is not in the published `files` (only `dist` is), so this adds tooling with no change to the shipped package.
- The last GHD-42 criterion — actually importing the bundle into Penpot and eyeballing collections/modes — is **deferred to Phase A (GHD-46)**, once the self-hosted instance exists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a command to generate a Penpot-compatible design token bundle.
  * Includes Light and Dark theme configurations, token metadata, inherited token types, and preserved aliases.
  * Validates token completeness and reports errors when tokens lack required type information.

* **Tests**
  * Added coverage for bundle structure, theme behavior, alias integrity, token typing, value preservation, and reference boundaries.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->