### PR TITLE
docs(skills): add ghds agent skill for consumer code generation

### DIFF
--- a/skills/ghds/SKILL.md
+++ b/skills/ghds/SKILL.md
@@ -1,0 +1,113 @@
+---
+name: ghds
+description: Generate correct, accessible UI code that consumes the GHDS design system (@ghds/react, @ghds/web-components, @ghds/react-native, @ghds/tokens). Use whenever writing or reviewing code that imports from any @ghds/* package.
+license: MIT
+---
+
+# GHDS
+
+GHDS (GH Design System) is a token-driven, cross-platform design system shipped as four npm packages: `@ghds/react`, `@ghds/web-components` (framework-agnostic Lit custom elements), `@ghds/react-native`, and `@ghds/tokens` (the shared design values all three consume). The same visual language is implemented three times — once per platform — so always check which platform you're generating code for before reaching for a prop name.
+
+Core rule, before anything else: **consume `sys.*`/`comp.*` design tokens, never hardcode colors/spacing/typography and never reference `ref.*` tokens directly.** See [rules/tokens.md](rules/tokens.md).
+
+## Installation
+
+```bash
+# React
+pnpm add @ghds/react @ghds/tokens
+
+# Framework-agnostic (Lit web components)
+pnpm add @ghds/web-components @ghds/tokens
+
+# React Native (inferred — not published on the getting-started page, but the
+# package is real and used throughout the pattern docs)
+pnpm add @ghds/react-native @ghds/tokens
+```
+
+Every React/Web Components value reads from CSS custom properties — import the token stylesheet once, at your app's entry point:
+
+```ts
+import '@ghds/tokens/css';
+```
+
+React Native has no stylesheet to import; tokens resolve as a plain JS object instead:
+
+```tsx
+import { tokens } from '@ghds/tokens';
+// tokens.sys.color.bg.primary, tokens.sys.spacing.component.md, ...
+```
+
+## Critical Rules
+
+Each rule below is enforced — follow the link for the full Incorrect/Correct code pairs.
+
+- **[Token usage](rules/tokens.md)** — always consume `sys.*`/`comp.*` tokens, never `ref.*` directly or a hardcoded value.
+- **[Accessibility](rules/accessibility.md)** — ARIA patterns, keyboard interaction, and focus management per component.
+- **[Composition](rules/composition.md)** — `FormField` wraps exactly one control; choosing between Toast/Alert/Modal and Skeleton/Spinner; debounce search inputs.
+- **[Platform differences](rules/platform-differences.md)** — prop and event naming diverges across React / Web Components / React Native. Never port a prop name from one platform to another without checking this file.
+
+## Key Patterns
+
+```tsx
+// Token CSS import — once, at app entry
+import '@ghds/tokens/css';
+```
+
+```tsx
+// FormField composition — wraps exactly one control, wires label/error/aria
+<FormField label="Email" helperText="We'll never share this." error={emailError}>
+  <Input type="email" />
+</FormField>
+```
+
+```
+// Feedback selection at a glance (full decision tree in rules/composition.md)
+User-initiated action, stays on screen        → Alert (inline, persistent)
+User-initiated action, then navigates away    → Toast (auto-dismiss)
+System event needing a decision               → Modal (interrupts, traps focus)
+System event, informational only              → Toast (auto-dismiss)
+```
+
+```tsx
+// React Native change events — NOT onChange (see rules/platform-differences.md)
+<Checkbox onCheckedChange={(checked) => setValue(checked)} />
+<Input onChangeText={(text) => setValue(text)} />
+```
+
+## Component Selection
+
+| Need | Component | Notes |
+|---|---|---|
+| Clickable action trigger | `Button` | `variant`: `primary`/`danger`/`neutral` on React & Web Components; React Native omits `neutral` |
+| Single-line text entry | `Input` | Pair with `FormField` for label/helper/error |
+| Multi-line text entry | `Textarea` | Pair with `FormField` |
+| Dropdown selection | `Select` | Pair with `FormField` |
+| Binary toggle (form-style) | `Checkbox` | React Native: `onCheckedChange`, not `onChange` |
+| Binary toggle (on/off setting) | `Switch` | React Native: `onCheckedChange`, not `onChange` |
+| Single choice from a set | `Radio` | Group multiple with the corresponding group component |
+| Numeric range input | `Slider` | No arrow-key stepping on React Native |
+| Label + helper + error wrapper | `FormField` | Wraps exactly one control — see [composition.md](rules/composition.md) |
+| Blocking dialog requiring a decision | `Modal` | `title` (React/React Native) vs `heading` (Web Components) |
+| Transient, non-blocking notification | `Toast` | Auto-dismiss ~5s |
+| Persistent inline status message | `Alert` | `role="status"` default, `role="alert"` for `danger` |
+| Contextual popup hint | `Tooltip` | `role="tooltip"`, `aria-describedby` |
+| Dropdown/contextual action list | `Menu` | Arrow-key navigation, Escape dismiss |
+| First-paint loading placeholder | `Skeleton` | Use when nothing is on screen yet |
+| Subsequent/inline loading indicator | `Spinner` | Use when existing content stays visible |
+| Multi-step or grouped navigation | `Tabs` | No roving-tabindex arrow nav on React Native |
+| Sequential step progress | `Progress` | Combine with `Tabs` for multi-step forms |
+| Tabular data display | `Table` | `sort`/`onSort` props for sortable columns |
+| Paged navigation control | `Pagination` | — |
+| Status/category label | `Badge` | Combine with a dismiss action for filter chips |
+| User identity image | `Avatar` | — |
+| Page/section location trail | `Breadcrumb` | — |
+| Card-style content container | `Card` | React: no default role, you supply one |
+| Collapsible sections | `Accordion` | — |
+
+## Reference
+
+- [rules/tokens.md](rules/tokens.md) — token consumption rules
+- [rules/accessibility.md](rules/accessibility.md) — ARIA, keyboard, focus management
+- [rules/composition.md](rules/composition.md) — component composition patterns
+- [rules/platform-differences.md](rules/platform-differences.md) — React / Web Components / React Native API differences
+- Full per-component prop tables and live demos: https://gyeonghokim.github.io/gyeongho-design-system/components/

--- a/skills/ghds/evals/evals.json
+++ b/skills/ghds/evals/evals.json
@@ -1,0 +1,86 @@
+{
+  "skill_name": "ghds",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
+      "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
+      "files": [],
+      "expectations": [
+        "Uses the `heading` attribute on <gh-modal>, not `title`",
+        "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
+      "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
+      "files": [],
+      "expectations": [
+        "Uses `onCheckedChange`, not `onChange`",
+        "The callback receives a bare boolean, not an event object"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Style a custom banner component to match our GHDS primary brand background and text color.",
+      "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
+      "files": [],
+      "expectations": [
+        "No hardcoded hex/rgb color values",
+        "References sys.* or comp.* tokens, not ref.* tokens"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
+      "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
+      "files": [],
+      "expectations": [
+        "Recommends or implements Toast, not Modal",
+        "Does not block user interaction or require an explicit dismiss action"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
+      "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
+      "files": [],
+      "expectations": [
+        "Uses FormField wrapping exactly one Input",
+        "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
+      "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
+      "files": [],
+      "expectations": [
+        "Does not set variant=\"neutral\" on the React Native Button",
+        "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
+      "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
+      "files": [],
+      "expectations": [
+        "Uses Skeleton for the initial load with no prior content",
+        "Uses Spinner for subsequent loads where content is already visible",
+        "Does not use Spinner for the first-paint case"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
+      "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
+      "files": [],
+      "expectations": [
+        "Applies a debounce (~300-400ms) before invoking the search/filter function",
+        "Does not call the search function synchronously on every onChange event"
+      ]
+    }
+  ]
+}

--- a/skills/ghds/rules/accessibility.md
+++ b/skills/ghds/rules/accessibility.md
@@ -1,0 +1,77 @@
+# Accessibility
+
+## Keyboard Interaction
+
+| Keys | Action |
+| --- | --- |
+| `Tab` | Move focus to the next focusable element in document order. |
+| `Shift + Tab` | Move focus to the previous focusable element. |
+| `Enter / Space` | Activate a focused Button. |
+| `Escape` | Close an open Modal (dismisses the dialog and restores focus to the trigger). Also dismisses Tooltip and Menu. |
+| `↑ ↓ ← →` | Navigate items within an open Menu (arrow keys), or cycle through Tabs (left/right arrows). |
+
+Most components (`Button`, `Card`, `Input`, `Alert`, `Badge`, `Avatar`, `Spinner`, `Progress`, `Skeleton`, `Table`) rely entirely on native browser keyboard handling — you don't need to add `onKeyDown`/`tabIndex` logic yourself. Overlay components (`Modal`, `Menu`, `Tooltip`) add their own bindings for dismissal and navigation. See `platform-differences.md` for where React Native's keyboard support falls short of this table.
+
+## ARIA Patterns by Component
+
+| Component | Pattern |
+| --- | --- |
+| `Button` | Native `<button>` role (or `aria-disabled` on the `asChild` path — see Focus Management below). |
+| `Card` | No role by default on React — you supply one. Web Components/React Native auto-expose `role="group"`/`accessibilityRole="summary"` when a `label` is given. |
+| `Input` | `aria-invalid` + `aria-describedby` (pointing at a `role="alert"` error message) wired automatically when used inside `FormField` with an `error` set. |
+| `Modal` | `role="dialog"` + `aria-modal="true"`, title wired via `aria-labelledby`. |
+| `Alert` | `role="status"` by default, `role="alert"` for the `danger` variant (assertive). |
+| `Toast` | `role="status"` (polite) for info/success/warning; `role="alert"` (assertive) for `danger`. |
+| `Tooltip` | `role="tooltip"`, trigger linked via `aria-describedby`. |
+| `Menu` | `role="menu"` with `role="menuitem"` on items; arrow-key navigation, Escape dismiss. |
+
+**Use `FormField` for error wiring instead of hand-rolling it.** `FormField` automatically wires `aria-describedby`/`aria-invalid` and gives the error text `role="alert"` — a hand-rolled error span next to an `Input` does not connect to it at all.
+
+```tsx
+// Incorrect — visually shows an error, but nothing wires it to the input for
+// screen readers; aria-invalid/aria-describedby are never set
+<Input error={hasError} />
+{hasError && <span className="error-text">Invalid email</span>}
+```
+
+```tsx
+// Correct — FormField wires aria-invalid + aria-describedby + role="alert"
+// automatically
+<FormField label="Email" error={hasError ? 'Invalid email' : undefined}>
+  <Input type="email" />
+</FormField>
+```
+
+## Focus Management
+
+- Always keep a visible focus ring — see `tokens.md`'s `comp.*.focus.ring` rule; never remove `outline` without replacing it.
+- A native `disabled` attribute removes an element from the tab order entirely. `Button`'s `asChild` path only sets `aria-disabled`, which does **not** remove it from the tab order — if you disable an `asChild` button, you must also prevent activation yourself.
+
+```tsx
+// Incorrect — assumes aria-disabled removes the element from the tab order (it
+// doesn't); a keyboard user can still Tab to and activate this "disabled" link
+<Button asChild disabled>
+  <a href="/checkout">Checkout</a>
+</Button>
+```
+
+```tsx
+// Correct — when using asChild, also guard activation manually, since
+// aria-disabled alone does not block Tab focus or Enter/Space activation
+<Button asChild aria-disabled={isDisabled}>
+  <a
+    href="/checkout"
+    onClick={(e) => { if (isDisabled) e.preventDefault(); }}
+    tabIndex={isDisabled ? -1 : undefined}
+  >
+    Checkout
+  </a>
+</Button>
+```
+
+- `Modal` and `Menu` trap focus while open and restore it to the triggering element on close.
+- `Toast` and `Tooltip` do **not** trap focus — they're transient/supplementary, so don't rely on them for a keyboard-only critical flow.
+
+## Color Contrast
+
+Every `sys.color.*` text/background pairing is validated at build time against WCAG 2.1 AA (4.5:1 for normal text, 3:1 for large text/icons/borders). This guarantee only holds when you consume `sys.*`/`comp.*` tokens — see `tokens.md` for the consumption rule this depends on.

--- a/skills/ghds/rules/composition.md
+++ b/skills/ghds/rules/composition.md
@@ -1,0 +1,131 @@
+# Composition Patterns
+
+GHDS components are deliberately small — most real UI is a *pattern*, a recipe combining several components. These are the recurring recipes and the decisions behind them.
+
+## FormField wraps exactly one control
+
+`FormField` composes a label, helper text, and error message around a **single** form control, wiring `id`/`aria-describedby`/`aria-invalid` to that one control. Wrapping more than one control breaks that wiring — only one of them ends up connected.
+
+```tsx
+// Incorrect — FormField composes around exactly one control; wrapping two
+// breaks its id/aria-describedby wiring
+<FormField label="Name">
+  <Input placeholder="First" />
+  <Input placeholder="Last" />
+</FormField>
+```
+
+```tsx
+// Correct — one FormField per control
+<FormField label="First name">
+  <Input />
+</FormField>
+<FormField label="Last name">
+  <Input />
+</FormField>
+```
+
+## Validate on blur + submit, not on every keystroke
+
+Validating on every keystroke is noisy and interrupts typing. Validate a field when it loses focus, and validate the whole form again on submit.
+
+```tsx
+// Incorrect — validates on every keystroke
+<Input onChange={(e) => { setValue(e.target.value); validate(e.target.value); }} />
+```
+
+```tsx
+// Correct — validate on blur (per-field), and again on submit (whole form)
+<Input
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  onBlur={() => validate(value)}
+/>
+```
+
+Also: mark required fields with an asterisk or "(required)" text, not color alone. For forms with more than ~5 fields (or cross-field validation), prefer a summary `Alert variant="danger"` at the top over per-field inline errors alone.
+
+## Choosing between Toast, Alert, and Modal
+
+Decision tree:
+- User-initiated action, result stays on screen → **Alert** (inline, persistent).
+- User-initiated action, then the user navigates away → **Toast** (auto-dismiss).
+- System event that needs a decision → **Modal** (interrupts, traps focus).
+- System event, informational only → **Toast** (auto-dismiss).
+
+| | Toast | Alert | Modal |
+|---|---|---|---|
+| Position | Fixed, bottom-right | Inline, in layout | Centered overlay with scrim |
+| Persistence | Auto-dismiss (default 5s) | Stays until dismissed | Stays until explicit close |
+| Interrupts | No | No | Yes (traps focus, locks scroll) |
+| Requires action | No | Optional dismiss | Yes (at minimum "OK"/"Cancel") |
+| Use for | "Saved", "Copied" | Form errors, status banners | Confirmations, detail views |
+| Stacking | Multiple can stack | One per context | One at a time — never nested |
+
+```tsx
+// Incorrect — Modal for a simple success message; too heavy, interrupts the
+// user and forces a dismiss action for something that needed none
+<Modal open={saved} title="Success" onClose={() => setSaved(false)}>
+  Your changes were saved.
+</Modal>
+```
+
+```tsx
+// Correct — Toast for a transient, non-blocking confirmation
+<Toast variant="success" open={saved} onClose={() => setSaved(false)}>
+  Your changes were saved.
+</Toast>
+```
+
+Don't rely on color alone to convey severity — always pair the color token with an icon and text.
+
+## Choosing between Skeleton and Spinner
+
+| State | Trigger | Component |
+|---|---|---|
+| Loading (first paint) | Page/view mounts, fetch starts, nothing on screen yet | `Skeleton` |
+| Loading (subsequent) | Filter change, pagination, refresh — existing content stays visible | `Spinner` |
+| Empty | Zero results | Message + `Button` for a next action |
+| Error | Network/server failure | `Alert variant="danger"` + retry `Button` |
+
+Rule of thumb: is there existing content on screen? No → `Skeleton`. Yes → `Spinner`.
+
+```tsx
+// Incorrect — Spinner on first paint blanks the whole layout unnecessarily,
+// when there's no existing content to preserve context around
+function ProductList() {
+  if (loading) return <Spinner />;
+  return <List items={products} />;
+}
+```
+
+```tsx
+// Correct — Skeleton on first paint (mimics eventual layout); Spinner only for
+// subsequent loads where existing content stays visible
+function ProductList() {
+  if (isFirstLoad) return <Skeleton />;
+  return (
+    <>
+      {isRefetching && <Spinner />}
+      <List items={products} />
+    </>
+  );
+}
+```
+
+Use a live region (`role="status"`) to announce result counts (e.g. "Showing 12 of 45 items") — a `Spinner` alone isn't announced to screen readers.
+
+## Debounce search inputs
+
+Firing a search request on every keystroke hammers the backend unnecessarily.
+
+```tsx
+// Incorrect — fires a network request on every keystroke
+<Input onChange={(e) => search(e.target.value)} />
+```
+
+```tsx
+// Correct — debounce 300-400ms before firing
+const debouncedSearch = useMemo(() => debounce(search, 350), []);
+<Input onChange={(e) => debouncedSearch(e.target.value)} />
+```

--- a/skills/ghds/rules/platform-differences.md
+++ b/skills/ghds/rules/platform-differences.md
@@ -1,0 +1,104 @@
+# Platform Differences
+
+GHDS ships the same design as three separate implementations — `@ghds/react`, `@ghds/web-components` (Lit, `gh-*` custom elements), and `@ghds/react-native`. They are **not** a single API with three renderers; prop names, event shapes, and even the supported variant set diverge in specific, verified ways. Do not port a prop name from one platform to another without checking this file first.
+
+## Modal accessible title: `title` vs `heading`
+
+React and React Native both use `title`. Web Components uses `heading` for the identical concept.
+
+```tsx
+// React / React Native
+<Modal title="Delete item?" open={open} onClose={onClose}>
+  ...
+</Modal>
+```
+
+```html
+<!-- Web Components — the prop is `heading`, not `title` -->
+<gh-modal heading="Delete item?" open>
+  ...
+</gh-modal>
+```
+
+**Gotcha:** `title` is also a native HTML global attribute (hover tooltip). Setting `title="Delete item?"` on `<gh-modal>` does not error — it silently renders a browser tooltip instead of wiring the dialog's accessible name. This is a wrong-behavior trap, not a compile-time catch.
+
+## Change events: three different shapes
+
+- **React** — native `onChange(event)`; read `event.target.value` / `event.target.checked`.
+- **Web Components** — no callback prop at all; the element dispatches a native DOM `change`/`input` event, so the consumer must `addEventListener`.
+- **React Native** — differently-named callbacks that receive a bare value, not an event: `onCheckedChange?: (checked: boolean) => void` (`Checkbox`, `Switch`) and `onChangeText?: (text: string) => void` (`Input` — note the name, it is **not** `onChange`).
+
+```tsx
+// React
+<Checkbox onChange={(e) => setChecked(e.target.checked)} />
+<Input onChange={(e) => setValue(e.target.value)} />
+```
+
+```html
+<!-- Web Components -->
+<gh-checkbox id="my-checkbox"></gh-checkbox>
+<script>
+  document.getElementById('my-checkbox').addEventListener('change', (e) => {
+    console.log(e.target.checked);
+  });
+</script>
+```
+
+```tsx
+// React Native — NOT onChange
+<Checkbox onCheckedChange={(checked) => setChecked(checked)} />
+<Switch onCheckedChange={(checked) => setChecked(checked)} />
+<Input onChangeText={(text) => setValue(text)} />
+```
+
+## Button content: children vs `label`-only
+
+React and Web Components accept arbitrary children/slotted content. React Native's `Button` only accepts a `label: string` prop — there is no children slot, so rich or composed content (an icon plus text, for example) is not possible.
+
+```tsx
+// React / Web Components — arbitrary children
+<Button variant="primary"><Icon name="save" /> Save changes</Button>
+```
+
+```tsx
+// Incorrect on React Native — Button has no children prop
+<Button><Icon name="save" /> Save changes</Button>
+
+// Correct on React Native — label is a plain string
+<Button label="Save changes" variant="primary" />
+```
+
+## Button `variant`: React Native has no `'neutral'`
+
+React and Web Components support `'primary' | 'danger' | 'neutral'`. React Native's `ButtonVariant` is `'primary' | 'danger'` only — `'neutral'` does not exist there.
+
+```tsx
+// React / Web Components — three variants
+<Button variant="neutral">Cancel</Button>
+```
+
+```tsx
+// Incorrect on React Native — 'neutral' is not in the RN ButtonVariant union;
+// this is a type error, not a silent fallback
+<Button label="Cancel" variant="neutral" />
+
+// Correct on React Native — only 'primary' | 'danger' exist; use 'primary' with
+// custom styling, or a plain Pressable, for a neutral/tertiary action
+<Button label="Cancel" variant="primary" />
+```
+
+## React-Native-only props
+
+`testID` and `accessibilityHint` exist only on React Native — they have no equivalent prop on React or Web Components. When porting a component's usage from React/Web Components to React Native, add them where useful for testing/accessibility; when porting the other direction, drop them (they don't exist elsewhere and TypeScript will reject them on React/Web Components).
+
+## Web-Components-only: native form participation
+
+`Button`, `Checkbox`, and `Switch` on Web Components participate in native `<form>` submission and reset via `ElementInternals`/form-association — a real `<form>` submit or reset affects them automatically. React has no equivalent (plain DOM form semantics apply instead — you wire submission yourself), and React Native has no native `<form>` concept at all.
+
+## Accessibility prop gaps on React Native
+
+Three distinct situations — do not treat them as equivalent:
+
+- **`accessibilityValue` / `accessibilityState`** — these nested RN accessibility objects are not forwarded to the DOM by react-native-web. You do not need to work around this yourself: GHDS's React Native components already set the flat ARIA equivalent (`aria-checked`, `aria-valuenow`, etc.) internally alongside them, so the ARIA output a screen reader sees is correct in practice. This is mentioned only so you understand why passing these props yourself has no additional effect.
+- **`onAccessibilityAction`** — genuinely unsupported when a React Native app is rendered via react-native-web. It's currently exposed only on `Slider`. If you need a custom accessibility action on `Slider` in a web-rendered React Native context, there is no supported workaround today.
+- **Keyboard interaction (`onKeyDown`-based)** — not implemented for React Native at all. This is a real feature gap, not a forwarding issue: `Slider` has no arrow-key stepping on React Native, and `Tabs` has no roving-tabindex arrow-key navigation on React Native. If your product needs full keyboard parity between the web platforms and React Native, plan around this explicitly.

--- a/skills/ghds/rules/tokens.md
+++ b/skills/ghds/rules/tokens.md
@@ -1,0 +1,84 @@
+# Token Usage
+
+Every GHDS component reads its colors, spacing, typography, radii, and other design values from `@ghds/tokens`. Tokens come in three tiers — `ref` (raw values), `sys` (semantic roles), and `comp` (component-specific overrides). As a consumer, think of these as three layers you can reference in your own styles, not as files you edit — you only ever consume `sys.*` and `comp.*`.
+
+## Consume `sys.*`/`comp.*`, never `ref.*` or hardcoded values
+
+`ref` tokens are raw, unthemed primitives. Referencing them directly (or hardcoding a color/spacing value yourself) bypasses GHDS's semantic layer — your value won't respond to theme/dark-mode changes, and it loses the WCAG contrast guarantee that only holds for `sys.color.*`/`comp.*` pairings.
+
+```css
+/* Incorrect — hardcoded value, bypasses the contrast-validated token system */
+.my-button {
+  background-color: #0066cc;
+  color: #ffffff;
+}
+```
+
+```css
+/* Correct — consumes a sys token, contrast-guaranteed against its paired text/bg */
+.my-button {
+  background-color: var(--sys-color-bg-primary);
+  color: var(--sys-color-text-onPrimary);
+}
+```
+
+## Import the token stylesheet once, at app entry
+
+React and Web Components components read their values from CSS custom properties. Without importing the stylesheet, every color/spacing value silently falls back to unset.
+
+```tsx
+// Incorrect — no token stylesheet imported anywhere; every token-driven value
+// (color, spacing, radius) falls back to unset
+import { Button } from '@ghds/react';
+
+function Page() {
+  return <Button variant="primary">Save</Button>;
+}
+```
+
+```tsx
+// Correct — import once, at the app's root/entry file
+import '@ghds/tokens/css';
+import { Button } from '@ghds/react';
+
+function Page() {
+  return <Button variant="primary">Save</Button>;
+}
+```
+
+## React Native: tokens are a JS object, not CSS
+
+React Native has no stylesheet to import. Import the `tokens` object directly and reference the same `sys.*`/`comp.*` paths as JS property access:
+
+```tsx
+import { tokens } from '@ghds/tokens';
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: tokens.sys.color.bg.primary,
+    paddingHorizontal: tokens.sys.spacing.component.md,
+  },
+});
+```
+
+The rule is unchanged across platforms: reference `sys`/`comp`, never `ref`, never a literal value.
+
+## Prefer `comp.*` over `sys.*` when a component-specific token exists
+
+Some components — like focus rings — have their own dedicated `comp.*` token rather than a general `sys.*` one. Removing an outline without replacing it with the component's focus-ring token breaks visible-focus accessibility.
+
+```css
+/* Incorrect — removes the focus ring without replacing it */
+.my-input:focus {
+  outline: none;
+}
+```
+
+```css
+/* Correct — replaces it with the component's own focus-ring token */
+.my-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--comp-input-focus-ring);
+}
+```


### PR DESCRIPTION
## Summary

Adds `skills/ghds/` — an Agent Skill that GHDS consumers install into their own AI coding agent (Claude Code, Cursor, etc.) via `npx skills add`, so it generates correct GHDS-consuming code instead of guessing. Follows shadcn/ui's `skills/shadcn/` structure (`SKILL.md` + `rules/*.md` with Incorrect/Correct pairs + `evals/evals.json`), adapted for GHDS's npm-install model (no dynamic CLI context injection, since there's no registry CLI).

Covers: token consumption (`sys`/`comp`, never `ref` or hardcoded values), accessibility (ARIA/keyboard/focus patterns), composition (FormField wrapping, Toast/Alert/Modal decision, Skeleton/Spinner decision), and verified prop/event differences across `@ghds/react`, `@ghds/web-components`, and `@ghds/react-native` (e.g. Modal `title` vs `heading`, RN `onCheckedChange`/`onChangeText` vs `onChange`, RN Button missing the `neutral` variant).

Source material is strictly GHDS's consumer-facing docs (`apps/website/src/pages/`) plus direct verification against component source — never `AGENTS.md` (contributor-only internal docs), since this skill's readers are external consumers, not GHDS contributors.

## Related Issue

Linear: https://linear.app/gyeongho/issue/GHD-49/고객용-ai-에이전트-skills-지원-skillmd-rules (M15 · Skills for Agents)

## Type of Change

- [x] Documentation

## Affected Packages

None — `skills/` is a new top-level directory, not a workspace package (no `package.json`, not matched by `pnpm-workspace.yaml`).

## Checklist

- [x] No hardcoded design values; all imported from `@ghds/tokens`.
- [x] Token tier boundaries respected (`comp -> sys -> ref`; components never reference `ref` directly).
- [x] `pnpm lint` passes.
- [ ] Added a changeset — not needed, docs-only per CONTRIBUTING.md's exemption for non-package changes.
- [x] Verified accessibility content matches `apps/website/src/pages/accessibility.mdx`.

## Additional Notes

Website `/skills` announcement page is a separate follow-up (GHD-50), intentionally out of scope here.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GHDS usage guidance for React, Web Components, and React Native.
  * Documented accessible keyboard interactions, ARIA patterns, focus management, and WCAG color-contrast requirements.
  * Added guidance for token usage, component composition, validation, feedback patterns, loading states, and debounced search.
  * Clarified platform-specific component APIs, events, accessibility properties, and form behavior.
* **Tests**
  * Added eight evaluation scenarios covering common GHDS implementation patterns and accessibility requirements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->