### PR TITLE
docs(skills): add /skills website page and cross-links

### DIFF
--- a/apps/website/src/lib/nav.ts
+++ b/apps/website/src/lib/nav.ts
@@ -57,4 +57,9 @@ export const NAV: readonly NavItem[] = [
     href: '/resources/',
     summary: 'A collection of links for packages, the repository, changelog, and more.',
   },
+  {
+    label: 'AI Agent Skills',
+    href: '/skills/',
+    summary: 'Install a skill so your AI coding assistant generates correct GHDS code.',
+  },
 ];

--- a/apps/website/src/pages/getting-started.mdx
+++ b/apps/website/src/pages/getting-started.mdx
@@ -51,3 +51,5 @@ import '@ghds/web-components';
 - [Design Style](../design-style/) — a gallery of color, typography, and spacing generated
   automatically from tokens
 - [Components](../components/) — a live demo comparing React and Lit side by side
+- [AI Agent Skills](../skills/) — install a skill so your AI coding assistant generates correct
+  GHDS code

--- a/apps/website/src/pages/resources.mdx
+++ b/apps/website/src/pages/resources.mdx
@@ -13,6 +13,12 @@ A collection of resources for using and contributing to GHDS.
 - `@ghds/web-components` — Lit-based framework-agnostic web components
 - `@ghds/react-native` — React Native component library
 
+## AI Agent Skills
+
+- [Skill source](https://github.com/GyeongHoKim/gyeongho-design-system/tree/main/skills/ghds) —
+  install via `npx skills add GyeongHoKim/gyeongho-design-system`. See the
+  [Skills page](../skills/) for details.
+
 ## Repository
 
 - [GitHub Repository](https://github.com/GyeongHoKim/gyeongho-design-system) — source code, issues,

--- a/apps/website/src/pages/skills.mdx
+++ b/apps/website/src/pages/skills.mdx
@@ -1,0 +1,77 @@
+---
+layout: ../layouts/MarkdownLayout.astro
+title: AI Agent Skills
+description: Install an Agent Skill so your AI coding assistant generates correct, accessible GHDS code.
+---
+
+GHDS ships an [Agent Skill](https://github.com/GyeongHoKim/gyeongho-design-system/tree/main/skills/ghds)
+— a set of rules and examples your AI coding assistant (Claude Code, Cursor, and other tools in the
+[vercel-labs/skills](https://github.com/vercel-labs/skills) ecosystem) reads before generating code
+that imports from `@ghds/*`. Instead of guessing prop names or hardcoding colors, it knows GHDS's
+actual conventions.
+
+## Installation
+
+```bash
+npx skills add GyeongHoKim/gyeongho-design-system
+```
+
+```bash
+pnpm dlx skills add GyeongHoKim/gyeongho-design-system
+```
+
+```bash
+bunx skills add GyeongHoKim/gyeongho-design-system
+```
+
+This installs the skill into your project's agent-skills directory (e.g. `.claude/skills/` for
+Claude Code). We've verified installation and usage with **Claude Code**; the skill follows the
+open [agentskills.io](https://agentskills.io) format supported by the wider vercel-labs/skills
+ecosystem, but we haven't verified every listed agent ourselves.
+
+## What's Included
+
+- **Token usage** — when to consume `sys.*`/`comp.*` tokens vs. why `ref.*` and hardcoded values
+  break the contrast guarantee.
+- **Accessibility** — the ARIA pattern and keyboard-interaction reference for every component, plus
+  focus-management gotchas (like the `asChild`+`disabled` tab-order trap).
+- **Composition** — when to reach for `FormField`, and how to choose between `Toast`/`Alert`/`Modal`
+  or `Skeleton`/`Spinner`.
+- **Platform differences** — the concrete prop and event-naming gaps between `@ghds/react`,
+  `@ghds/web-components`, and `@ghds/react-native` (for example, `Modal`'s accessible title is
+  `title` on React/React Native but `heading` on Web Components).
+
+## Before / After
+
+Without the skill, an agent will often hardcode a color:
+
+```css
+/* Before */
+.my-button {
+  background-color: #0066cc;
+}
+```
+
+```css
+/* After */
+.my-button {
+  background-color: var(--sys-color-bg-primary);
+}
+```
+
+...or carry a prop name across platforms that doesn't exist there:
+
+```tsx
+// Before — 'neutral' isn't a valid variant on React Native
+<Button label="Cancel" variant="neutral" />
+```
+
+```tsx
+// After
+<Button label="Cancel" variant="primary" />
+```
+
+## Reference
+
+- [Skill source](https://github.com/GyeongHoKim/gyeongho-design-system/tree/main/skills/ghds)
+- [Getting Started](../getting-started/) — installing the packages themselves


### PR DESCRIPTION
## Summary

Announces the `ghds` Agent Skill (shipped in GHD-49, PR #54) on the GHDS website:

- New `/skills` page — what an Agent Skill is, installation (`npx skills add`, `pnpm dlx`, `bunx` variants), what's included (token usage, accessibility, composition, platform differences), and a before/after code example.
- `getting-started.mdx` — a new "Next Steps" link.
- `resources.mdx` — a new "AI Agent Skills" section.
- `nav.ts` — one new `NAV` entry, which automatically surfaces the page in both the site header nav and the homepage card grid (`index.astro` maps over `NAV` directly, confirmed no separate edit needed there).

Page name/path is `/skills`, matching shadcn/ui's `/docs/skills` convention (not `/agents`), per the earlier direction to benchmark shadcn's approach.

## Related Issue

Linear: GHD-50 (M15 · Skills for Agents, follow-up to GHD-49/#54)

## Type of Change

- [x] Documentation

## Affected Packages

None — `apps/website` is a private, non-published app.

## Checklist

- [x] `pnpm lint` passes.
- [ ] Changeset — not needed, `apps/website` is private/docs-only per CONTRIBUTING.md's exemption.
- [x] Content verified against the actual shipped `skills/ghds/SKILL.md` — no drift.

## Verification performed

- `pnpm --filter @ghds/website build` succeeds, `/skills/index.html` generated correctly.
- Ran `npx skills add GyeongHoKim/gyeongho-design-system` in a scratch directory — confirms the skill is discoverable and installs correctly into `.claude/skills/ghds`, matching the page's "verified with Claude Code" claim.
- Homepage build output confirms the new nav link/card render (`AI Agent Skills` appears twice: header nav + homepage card grid).

## Additional Notes

`llms.txt`/MCP server/skills.sh catalog mentions are intentionally out of scope, per GHD-50.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an AI Agent Skills page with installation instructions and guidance for generating GHDS code.
  * Documented token usage, accessibility, keyboard interactions, composition patterns, and platform differences.
  * Added before-and-after examples and links to related resources.

* **Documentation**
  * Added AI Agent Skills links to site navigation, Getting Started, and Resources pages.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->