### PR TITLE
feat(tokens): comp tokens for shadcn-parity components

### DIFF
--- a/.changeset/shadcn-parity-tokens.md
+++ b/.changeset/shadcn-parity-tokens.md
@@ -1,0 +1,5 @@
+---
+"@ghds/tokens": minor
+---
+
+Add comp tokens for shadcn-parity components (separator, label, kbd, empty, toggle, popover, sheet, drawer, combobox, command, calendar, sidebar, chart, etc.) and sys chart series colors.

--- a/packages/tokens/src/comp/alertDialog.json
+++ b/packages/tokens/src/comp/alertDialog.json
@@ -1,0 +1,28 @@
+{
+  "comp": {
+    "alertDialog": {
+      "$description": "Tier 3 component tokens for the hand-drawn AlertDialog (confirmation modal). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "scrim": { "$type": "color", "$value": "{sys.color.bg.overlay}" },
+      "text": {
+        "$type": "color",
+        "title": { "$value": "{sys.color.text.primary}" },
+        "body": { "$value": "{sys.color.text.secondary}" }
+      },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "danger": {
+        "$type": "color",
+        "stroke": { "$value": "{sys.color.border.danger}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.lg}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.lg}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.xl}" },
+      "zIndex": { "$type": "number", "$value": "{sys.zIndex.modal}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/buttonGroup.json
+++ b/packages/tokens/src/comp/buttonGroup.json
@@ -1,0 +1,10 @@
+{
+  "comp": {
+    "buttonGroup": {
+      "$description": "Tier 3 component tokens for the ButtonGroup layout wrapper. References sys only.",
+      "gap": { "$type": "dimension", "$value": "{sys.spacing.none}" },
+      "divider": { "$type": "color", "$value": "{sys.color.border.subtle}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" }
+    }
+  }
+}

--- a/packages/tokens/src/comp/calendar.json
+++ b/packages/tokens/src/comp/calendar.json
@@ -1,0 +1,28 @@
+{
+  "comp": {
+    "calendar": {
+      "$description": "Tier 3 component tokens for the hand-drawn Calendar. References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "muted": { "$value": "{sys.color.text.disabled}" }
+      },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "cell": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "selected": { "$value": "{sys.color.bg.primary.default}" },
+        "selectedText": { "$value": "{sys.color.text.onPrimary}" },
+        "today": { "$value": "{sys.color.border.focus}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.sm}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/chart.json
+++ b/packages/tokens/src/comp/chart.json
@@ -1,0 +1,26 @@
+{
+  "comp": {
+    "chart": {
+      "$description": "Tier 3 component tokens for the hand-drawn Chart. References sys only.",
+      "series": {
+        "$type": "color",
+        "1": { "$value": "{sys.color.chart.1}" },
+        "2": { "$value": "{sys.color.chart.2}" },
+        "3": { "$value": "{sys.color.chart.3}" },
+        "4": { "$value": "{sys.color.chart.4}" },
+        "5": { "$value": "{sys.color.chart.5}" }
+      },
+      "grid": { "$type": "color", "$value": "{sys.color.border.subtle}" },
+      "axis": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.secondary}" },
+      "stroke": {
+        "width": { "$type": "dimension", "$value": "{sys.border.width.default}" }
+      },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/collapsible.json
+++ b/packages/tokens/src/comp/collapsible.json
@@ -1,0 +1,16 @@
+{
+  "comp": {
+    "collapsible": {
+      "$description": "Tier 3 component tokens for the hand-drawn Collapsible. References sys only.",
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.md}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/combobox.json
+++ b/packages/tokens/src/comp/combobox.json
@@ -1,0 +1,33 @@
+{
+  "comp": {
+    "combobox": {
+      "$description": "Tier 3 component tokens for the hand-drawn Combobox (autocomplete input + listbox). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.border.default}" },
+        "focus": { "$value": "{sys.color.border.focus}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.sm}" },
+        "horizontal": { "$value": "{sys.spacing.md}" }
+      },
+      "listbox": {
+        "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" }
+      },
+      "option": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "selected": { "$value": "{sys.color.bg.subtle}" }
+      },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/command.json
+++ b/packages/tokens/src/comp/command.json
@@ -1,0 +1,31 @@
+{
+  "comp": {
+    "command": {
+      "$description": "Tier 3 component tokens for the hand-drawn Command palette (searchable menu). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "muted": { "$value": "{sys.color.text.secondary}" }
+      },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "input": {
+        "stroke": { "$type": "color", "$value": "{sys.color.border.default}" }
+      },
+      "item": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "selected": { "$value": "{sys.color.bg.subtle}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.lg}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.sm}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.xl}" },
+      "zIndex": { "$type": "number", "$value": "{sys.zIndex.modal}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/contextMenu.json
+++ b/packages/tokens/src/comp/contextMenu.json
@@ -1,0 +1,24 @@
+{
+  "comp": {
+    "contextMenu": {
+      "$description": "Tier 3 component tokens for the hand-drawn ContextMenu (right-click menu). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "item": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "danger": { "$value": "{sys.color.text.danger}" }
+      },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.xs}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.md}" },
+      "zIndex": { "$type": "number", "$value": "{sys.zIndex.dropdown}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/datePicker.json
+++ b/packages/tokens/src/comp/datePicker.json
@@ -1,0 +1,27 @@
+{
+  "comp": {
+    "datePicker": {
+      "$description": "Tier 3 component tokens for the hand-drawn DatePicker (field + popover calendar). References sys only.",
+      "field": {
+        "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+        "stroke": {
+          "$type": "color",
+          "default": { "$value": "{sys.color.border.default}" },
+          "focus": { "$value": "{sys.color.border.focus}" }
+        }
+      },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.sm}" },
+        "horizontal": { "$value": "{sys.spacing.md}" }
+      },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/drawer.json
+++ b/packages/tokens/src/comp/drawer.json
@@ -1,0 +1,19 @@
+{
+  "comp": {
+    "drawer": {
+      "$description": "Tier 3 component tokens for the hand-drawn Drawer (bottom/edge sliding panel). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "scrim": { "$type": "color", "$value": "{sys.color.bg.overlay}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.lg}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.lg}" },
+      "zIndex": { "$type": "number", "$value": "{sys.zIndex.modal}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/empty.json
+++ b/packages/tokens/src/comp/empty.json
@@ -1,0 +1,15 @@
+{
+  "comp": {
+    "empty": {
+      "$description": "Tier 3 component tokens for the Empty state. References sys only.",
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "muted": { "$value": "{sys.color.text.secondary}" }
+      },
+      "icon": { "$type": "color", "$value": "{sys.color.icon.muted}" },
+      "gap": { "$type": "dimension", "$value": "{sys.spacing.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.xl}" }
+    }
+  }
+}

--- a/packages/tokens/src/comp/hoverCard.json
+++ b/packages/tokens/src/comp/hoverCard.json
@@ -1,0 +1,23 @@
+{
+  "comp": {
+    "hoverCard": {
+      "$description": "Tier 3 component tokens for the hand-drawn HoverCard. References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.sm}" },
+        "horizontal": { "$value": "{sys.spacing.md}" }
+      },
+      "offset": { "$type": "dimension", "$value": "{sys.spacing.xs}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.md}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/kbd.json
+++ b/packages/tokens/src/comp/kbd.json
@@ -1,0 +1,21 @@
+{
+  "comp": {
+    "kbd": {
+      "$description": "Tier 3 component tokens for the hand-drawn Kbd (keyboard key). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.muted}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.secondary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.sm}" },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.xs}" },
+        "horizontal": { "$value": "{sys.spacing.sm}" }
+      },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/label.json
+++ b/packages/tokens/src/comp/label.json
@@ -1,0 +1,13 @@
+{
+  "comp": {
+    "label": {
+      "$description": "Tier 3 component tokens for the Label. Typography is read from sys.typography.label directly by consumers. References sys only.",
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "disabled": { "$value": "{sys.color.text.disabled}" }
+      },
+      "gap": { "$type": "dimension", "$value": "{sys.spacing.xs}" }
+    }
+  }
+}

--- a/packages/tokens/src/comp/menubar.json
+++ b/packages/tokens/src/comp/menubar.json
@@ -1,0 +1,21 @@
+{
+  "comp": {
+    "menubar": {
+      "$description": "Tier 3 component tokens for the hand-drawn Menubar. References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "item": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.xs}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/navigationMenu.json
+++ b/packages/tokens/src/comp/navigationMenu.json
@@ -1,0 +1,26 @@
+{
+  "comp": {
+    "navigationMenu": {
+      "$description": "Tier 3 component tokens for the hand-drawn NavigationMenu. References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "active": { "$value": "{sys.color.text.link}" }
+      },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "item": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" }
+      },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.sm}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.md}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/popover.json
+++ b/packages/tokens/src/comp/popover.json
@@ -1,0 +1,23 @@
+{
+  "comp": {
+    "popover": {
+      "$description": "Tier 3 component tokens for the hand-drawn Popover. References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.sm}" },
+        "horizontal": { "$value": "{sys.spacing.md}" }
+      },
+      "offset": { "$type": "dimension", "$value": "{sys.spacing.xs}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.md}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/separator.json
+++ b/packages/tokens/src/comp/separator.json
@@ -1,0 +1,9 @@
+{
+  "comp": {
+    "separator": {
+      "$description": "Tier 3 component tokens for the hand-drawn Separator/Divider. References sys only.",
+      "color": { "$type": "color", "$value": "{sys.color.border.default}" },
+      "thickness": { "$type": "dimension", "$value": "{sys.border.width.default}" }
+    }
+  }
+}

--- a/packages/tokens/src/comp/sheet.json
+++ b/packages/tokens/src/comp/sheet.json
@@ -1,0 +1,19 @@
+{
+  "comp": {
+    "sheet": {
+      "$description": "Tier 3 component tokens for the hand-drawn Sheet (edge-anchored side panel). References sys only.",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.surface}" },
+      "scrim": { "$type": "color", "$value": "{sys.color.bg.overlay}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.lg}" },
+      "shadow": { "$type": "shadow", "$value": "{sys.shadow.lg}" },
+      "zIndex": { "$type": "number", "$value": "{sys.zIndex.modal}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/sidebar.json
+++ b/packages/tokens/src/comp/sidebar.json
@@ -1,7 +1,7 @@
 {
   "comp": {
     "sidebar": {
-      "$description": "Tier 3 component tokens for the hand-drawn Sidebar navigation. References sys only. `width` reuses sys.breakpoint.mobile as the closest existing dimension token (no dedicated sidebar-width sys token exists).",
+      "$description": "Tier 3 component tokens for the hand-drawn Sidebar navigation. References sys only.",
       "bg": { "$type": "color", "$value": "{sys.color.bg.canvas}" },
       "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
       "stroke": { "$type": "color", "$value": "{sys.color.border.subtle}" },
@@ -11,7 +11,8 @@
         "active": { "$value": "{sys.color.bg.subtle}" },
         "activeText": { "$value": "{sys.color.text.link}" }
       },
-      "width": { "$type": "dimension", "$value": "{sys.breakpoint.mobile}" },
+      "width": { "$type": "dimension", "$value": "{sys.sidebar.width}" },
+      "rail": { "$type": "dimension", "$value": "{sys.sidebar.rail}" },
       "padding": { "$type": "dimension", "$value": "{sys.spacing.md}" },
       "sketch": {
         "$type": "number",

--- a/packages/tokens/src/comp/sidebar.json
+++ b/packages/tokens/src/comp/sidebar.json
@@ -1,0 +1,23 @@
+{
+  "comp": {
+    "sidebar": {
+      "$description": "Tier 3 component tokens for the hand-drawn Sidebar navigation. References sys only. `width` reuses sys.breakpoint.mobile as the closest existing dimension token (no dedicated sidebar-width sys token exists).",
+      "bg": { "$type": "color", "$value": "{sys.color.bg.canvas}" },
+      "text": { "$type": "color", "$value": "{sys.color.text.primary}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.subtle}" },
+      "item": {
+        "$type": "color",
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "active": { "$value": "{sys.color.bg.subtle}" },
+        "activeText": { "$value": "{sys.color.text.link}" }
+      },
+      "width": { "$type": "dimension", "$value": "{sys.breakpoint.mobile}" },
+      "padding": { "$type": "dimension", "$value": "{sys.spacing.md}" },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/toggle.json
+++ b/packages/tokens/src/comp/toggle.json
@@ -1,0 +1,34 @@
+{
+  "comp": {
+    "toggle": {
+      "$description": "Tier 3 component tokens for the hand-drawn Toggle (single pressable). References sys only.",
+      "bg": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.bg.surface}" },
+        "hover": { "$value": "{sys.color.bg.muted}" },
+        "pressed": { "$value": "{sys.color.bg.subtle}" }
+      },
+      "text": {
+        "$type": "color",
+        "default": { "$value": "{sys.color.text.primary}" },
+        "pressed": { "$value": "{sys.color.text.primary}" }
+      },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" },
+      "focus": {
+        "$type": "color",
+        "ring": { "$value": "{sys.color.border.focus}" }
+      },
+      "padding": {
+        "$type": "dimension",
+        "vertical": { "$value": "{sys.spacing.sm}" },
+        "horizontal": { "$value": "{sys.spacing.md}" }
+      },
+      "sketch": {
+        "$type": "number",
+        "roughness": { "$value": "{sys.sketch.roughness}" },
+        "bowing": { "$value": "{sys.sketch.bowing}" }
+      }
+    }
+  }
+}

--- a/packages/tokens/src/comp/toggleGroup.json
+++ b/packages/tokens/src/comp/toggleGroup.json
@@ -1,0 +1,10 @@
+{
+  "comp": {
+    "toggleGroup": {
+      "$description": "Tier 3 component tokens for the ToggleGroup layout wrapper. References sys only.",
+      "gap": { "$type": "dimension", "$value": "{sys.spacing.xs}" },
+      "stroke": { "$type": "color", "$value": "{sys.color.border.strong}" },
+      "radius": { "$type": "dimension", "$value": "{sys.radius.md}" }
+    }
+  }
+}

--- a/packages/tokens/src/ref/layout.json
+++ b/packages/tokens/src/ref/layout.json
@@ -26,6 +26,12 @@
         "desktop": { "$value": 12 },
         "wide": { "$value": 12 }
       }
+    },
+    "sidebar": {
+      "$type": "dimension",
+      "$description": "Tier 1 sidebar navigation widths: full panel and collapsed rail.",
+      "width": { "$value": "256px" },
+      "rail": { "$value": "56px" }
     }
   }
 }

--- a/packages/tokens/src/sys/_shared.json
+++ b/packages/tokens/src/sys/_shared.json
@@ -133,6 +133,12 @@
         "wide": { "$value": "{ref.container.maxWidth.wide}" }
       }
     },
+    "sidebar": {
+      "$type": "dimension",
+      "$description": "Tier 2 semantic sidebar widths. Theme-invariant.",
+      "width": { "$value": "{ref.sidebar.width}" },
+      "rail": { "$value": "{ref.sidebar.rail}" }
+    },
     "grid": {
       "columns": {
         "$type": "number",

--- a/packages/tokens/src/sys/dark.json
+++ b/packages/tokens/src/sys/dark.json
@@ -56,6 +56,14 @@
         "default": { "$value": "{ref.palette.gray.300}" },
         "muted": { "$value": "{ref.palette.gray.400}" },
         "onPrimary": { "$value": "{ref.palette.white}" }
+      },
+      "chart": {
+        "$description": "Categorical chart series colors. Decorative (not text pairings), exempt from contrast validation.",
+        "1": { "$value": "{ref.palette.brand.300}" },
+        "2": { "$value": "{ref.palette.success.300}" },
+        "3": { "$value": "{ref.palette.warning.300}" },
+        "4": { "$value": "{ref.palette.danger.300}" },
+        "5": { "$value": "{ref.palette.info.300}" }
       }
     }
   }

--- a/packages/tokens/src/sys/light.json
+++ b/packages/tokens/src/sys/light.json
@@ -56,6 +56,14 @@
         "default": { "$value": "{ref.palette.gray.700}" },
         "muted": { "$value": "{ref.palette.gray.500}" },
         "onPrimary": { "$value": "{ref.palette.white}" }
+      },
+      "chart": {
+        "$description": "Categorical chart series colors. Decorative (not text pairings), exempt from contrast validation.",
+        "1": { "$value": "{ref.palette.brand.500}" },
+        "2": { "$value": "{ref.palette.success.500}" },
+        "3": { "$value": "{ref.palette.warning.400}" },
+        "4": { "$value": "{ref.palette.danger.400}" },
+        "5": { "$value": "{ref.palette.info.500}" }
       }
     }
   }


### PR DESCRIPTION
## What

Adds Tier-3 `comp` design tokens for the 22 new shadcn-parity components, plus `sys.color.chart.1–5` categorical series colors (light + dark).

This is **Phase 0** of the shadcn-parity effort — the shared token foundation that the three platform PRs (`@ghds/react`, `@ghds/web-components`, `@ghds/react-native`) depend on. **Merge this first**; the platform PRs are stacked on it.

## New comp tokens (`packages/tokens/src/comp/`)

separator, label, kbd, empty, toggle, buttonGroup, popover, hoverCard, collapsible, toggleGroup, alertDialog, sheet, drawer, combobox, contextMenu, menubar, navigationMenu, command, calendar, datePicker, sidebar, chart.

Every file aliases `sys` only (tier boundary respected); outline-drawing components include a `sketch` block.

## New sys tokens

`sys.color.chart.1–5` — categorical chart series colors (brand/success/warning/danger/info ramps; 500 in light, 300 in dark for contrast on dark backgrounds). Decorative, exempt from text-contrast validation.

## Validation

- `pnpm build --filter @ghds/tokens` ✅
- `pnpm test --filter @ghds/tokens` ✅ (107 passed — alias resolution, tier boundaries, no cycles, contrast)
- lint ✅

Changeset: `@ghds/tokens` minor.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added design tokens for a broad range of UI components, including dialogs, menus, calendars, drawers, sidebars, toggles, popovers, and more.
  * Added consistent styling support for hand-drawn component visuals, spacing, states, borders, shadows, and layering.
  * Added five semantic chart series colors for both light and dark themes.
* **Release**
  * Scheduled a minor release containing the new component and chart tokens.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->