### PR TITLE
docs(repo): agent skills, Code of Conduct & Security Policy

### DIFF
--- a/.agents/skills/ghds/SKILL.md
+++ b/.agents/skills/ghds/SKILL.md
@@ -1,0 +1,186 @@
+---
+name: ghds
+description: Generate correct, accessible UI code that consumes the GHDS design system (@ghds/react, @ghds/web-components, @ghds/react-native, @ghds/tokens). Use whenever writing or reviewing code that imports from any @ghds/* package.
+license: MIT
+---
+
+# GHDS
+
+GHDS (GH Design System) is a token-driven, cross-platform design system shipped as four npm packages: `@ghds/react`, `@ghds/web-components` (framework-agnostic Lit custom elements), `@ghds/react-native`, and `@ghds/tokens` (the shared design values all three consume). The same visual language is implemented three times — once per platform — so always check which platform you're generating code for before reaching for a prop name.
+
+Core rule, before anything else: **consume `sys.*`/`comp.*` design tokens, never hardcode colors/spacing/typography and never reference `ref.*` tokens directly.** See [rules/tokens.md](rules/tokens.md).
+
+## Installation
+
+```bash
+# React
+pnpm add @ghds/react @ghds/tokens
+
+# Framework-agnostic (Lit web components)
+pnpm add @ghds/web-components @ghds/tokens
+
+# React Native (inferred — not published on the getting-started page, but the
+# package is real and used throughout the pattern docs)
+pnpm add @ghds/react-native @ghds/tokens
+```
+
+Every React/Web Components value reads from CSS custom properties — import the token stylesheet once, at your app's entry point:
+
+```ts
+import '@ghds/tokens/css';
+```
+
+React Native has no stylesheet to import; tokens resolve as a plain JS object instead:
+
+```tsx
+import { tokens } from '@ghds/tokens';
+// tokens.sys.color.bg.primary, tokens.sys.spacing.component.md, ...
+```
+
+## Critical Rules
+
+Each rule below is enforced — follow the link for the full Incorrect/Correct code pairs.
+
+- **[Token usage](rules/tokens.md)** — always consume `sys.*`/`comp.*` tokens, never `ref.*` directly or a hardcoded value.
+- **[Accessibility](rules/accessibility.md)** — ARIA patterns, keyboard interaction, and focus management per component.
+- **[Composition](rules/composition.md)** — `FormField` wraps exactly one control; choosing between Toast/Alert/Modal and Skeleton/Spinner; debounce search inputs.
+- **[Platform differences](rules/platform-differences.md)** — prop and event naming diverges across React / Web Components / React Native. Never port a prop name from one platform to another without checking this file.
+
+## Key Patterns
+
+```tsx
+// Token CSS import — once, at app entry
+import '@ghds/tokens/css';
+```
+
+```tsx
+// FormField composition — wraps exactly one control, wires label/error/aria
+<FormField label="Email" helperText="We'll never share this." error={emailError}>
+  <Input type="email" />
+</FormField>
+```
+
+```
+// Feedback selection at a glance (full decision tree in rules/composition.md)
+User-initiated action, stays on screen        → Alert (inline, persistent)
+User-initiated action, then navigates away    → Toast (auto-dismiss)
+System event needing a decision               → Modal (interrupts, traps focus)
+System event, informational only              → Toast (auto-dismiss)
+```
+
+```tsx
+// React Native change events — NOT onChange (see rules/platform-differences.md)
+<Checkbox onCheckedChange={(checked) => setValue(checked)} />
+<Input onChangeText={(text) => setValue(text)} />
+```
+
+## Component Selection
+
+All components below exist on all three platforms (`@ghds/react`, `@ghds/web-components`, `@ghds/react-native`). The **Notes** column flags the single most common cross-platform gotcha; the full, source-verified divergence list is in [rules/platform-differences.md](rules/platform-differences.md). "WC" = Web Components, "RN" = React Native.
+
+### Forms & inputs
+
+| Need | Component | Notes |
+|---|---|---|
+| Clickable action trigger | `Button` | `variant`: `primary`/`danger`/`neutral` on React & WC; RN omits `neutral` and takes `label: string` only (no children) |
+| Group related buttons | `ButtonGroup` | RN `orientation: 'row'\|'column'` vs React/WC `'horizontal'\|'vertical'` |
+| Single-line text entry | `Input` | Pair with `FormField`; RN change event is `onChangeText`, not `onChange` |
+| Input with inline addons | `InputGroup` | Wraps an input + prefix/suffix addons in one box; RN addons are icon/text only |
+| One-time-code entry | `InputOTP` | WC dispatches `gh-change`/`gh-complete` events (no callback) and is controlled-only (no `defaultValue`) |
+| Multi-line text entry | `Textarea` | Pair with `FormField` |
+| Dropdown selection | `Select` | Pair with `FormField` |
+| Native platform select | `NativeSelect` | React `<option>` children + `onChange` + `error`; RN `items[]` + `selectedValue`/`onValueChange`; WC slotted `<select>` + `invalid` (no `error`) |
+| Searchable single-select | `Combobox` | React is an inline input+listbox; RN is a modal picker; empty-text prop `emptyMessage` (React) vs `emptyText` (RN) |
+| Binary toggle (form-style) | `Checkbox` | RN: `onCheckedChange`, not `onChange` |
+| Group of checkboxes | `CheckboxGroup` | React/RN share `value: string[]`+`onValueChange`; WC is presentational (each `gh-checkbox` self-manages) |
+| Single choice from a set | `Radio` | Group with `RadioGroup` |
+| Mutually-exclusive radios | `RadioGroup` | WC has no shared `value`/`onValueChange` (children self-manage); React shares `name` via context |
+| Binary toggle (on/off setting) | `Switch` | RN: `onCheckedChange`, not `onChange` |
+| Numeric range input | `Slider` | No arrow-key stepping on RN |
+| Two-state pressed button | `Toggle` | RN requires `label`; WC is form-associated, fires `change` (no `onPressedChange`/`defaultPressed`) |
+| Group of toggles (single/multi) | `ToggleGroup` | React types `value` by mode (`string`\|`string[]`); RN/WC always `string[]`; RN `orientation: 'row'\|'column'` |
+| Date field + calendar | `DatePicker` | WC `value` is an ISO string + `change` event; React/RN use `Date` + `onChange` |
+| Month-grid date selection | `Calendar` | Select cb differs: React `onSelect(Date)`, RN `onChange(Date)`, WC `select` event (ISO string) |
+| Form label | `Label` | Association prop: React `htmlFor`, RN `nativeID`, WC `for` |
+| Label + helper + error wrapper | `FormField` | Wraps exactly one control — see [composition.md](rules/composition.md) |
+
+### Overlays & dialogs
+
+| Need | Component | Notes |
+|---|---|---|
+| Blocking dialog requiring a decision | `Modal` | `title` (React/RN) vs `heading` (WC) |
+| Confirm/cancel dialog | `AlertDialog` | WC uses `heading` not `title`, and `variant: 'default'\|'danger'` vs React/RN `destructive` boolean |
+| Bottom drawer / tray | `Drawer` | WC `heading` not `title`; RN has no `closeOnScrimClick` |
+| Edge-anchored side panel | `Sheet` | `side`: left/right/top/bottom; WC `heading` not `title`; RN has no `closeOnScrimClick` |
+| Click-triggered floating panel | `Popover` | RN requires `triggerLabel` and has no `placement`; WC dispatches no open-change event |
+| Hover-reveal card | `HoverCard` | RN has no hover — opens on long-press and requires `triggerLabel` |
+| Contextual popup hint | `Tooltip` | `role="tooltip"`, `aria-describedby` |
+| Dropdown/contextual action list | `Menu` | Arrow-key navigation, Escape dismiss |
+| Horizontal menu bar | `Menubar` | RN `onSelect(menuValue, itemValue)` (two args); WC `menu-select` event |
+| Right-click / long-press menu | `ContextMenu` | React opens on right-click of `children`; RN long-press + `triggerLabel`; danger flag `danger`(React)/`destructive`(RN)/`dangerValues[]`(WC) |
+| Command palette | `Command` | React `groups[]` + a separate `CommandDialog`; RN/WC take flat `items[]` and are themselves modal |
+
+### Navigation
+
+| Need | Component | Notes |
+|---|---|---|
+| Multi-step or grouped navigation | `Tabs` | No roving-tabindex arrow nav on RN |
+| Page/section location trail | `Breadcrumb` | — |
+| Paged navigation control | `Pagination` | — |
+| Top-level nav with dropdown links | `NavigationMenu` | React/WC are href-based (`<a>`); RN is selection-callback (`value`+`onSelect`, no `href`) |
+| App navigation sidebar | `Sidebar` | React/RN data-driven (`sections`); WC slot-based; RN has no collapse; section heading prop React `.heading` vs RN `.title` |
+
+### Feedback & status
+
+| Need | Component | Notes |
+|---|---|---|
+| Transient, non-blocking notification | `Toast` | Auto-dismiss ~5s |
+| Persistent inline status message | `Alert` | `role="status"` default, `role="alert"` for `danger` |
+| Sequential step progress | `Progress` | Combine with `Tabs` for multi-step forms |
+| First-paint loading placeholder | `Skeleton` | Use when nothing is on screen yet |
+| Subsequent/inline loading indicator | `Spinner` | Use when existing content stays visible |
+| Status/category label | `Badge` | Combine with a dismiss action for filter chips |
+| Empty-state placeholder | `Empty` | WC `heading` not `title`; action slot React `action` / RN `children` / WC `actions` |
+
+### Layout & containers
+
+| Need | Component | Notes |
+|---|---|---|
+| Card-style content container | `Card` | React: no default role, you supply one |
+| Collapsible sections | `Accordion` | — |
+| Single disclosure toggle | `Collapsible` | WC is `open` + `toggle` event (no `defaultOpen`/controlled split) |
+| Divider between content | `Separator` | `decorative` defaults to `true` on RN vs `false` on React/WC — changes a11y exposure |
+| Bounded scroll viewport | `ScrollArea` | `orientation`: vertical/horizontal/both; RN cannot theme the native scrollbar |
+| Fixed-ratio box | `AspectRatio` | Constrain content to a width/height `ratio` |
+| Draggable split panels | `Resizable` | Compound Panel/Handle/Group; no arrow-key resize on RN (touch-drag only) |
+| Scroll-snap carousel | `Carousel` | RN adds a `CarouselIndicators` sub-component; WC renders its own controls + dots |
+| Propagate text direction | `Direction` | React/RN `DirectionProvider` + `useDirection()`; WC `<gh-direction dir>`; RN default derives from `I18nManager.isRTL` |
+
+### Data display
+
+| Need | Component | Notes |
+|---|---|---|
+| Tabular data display | `Table` | `sort`/`onSort` props for sortable columns |
+| Bar/line chart | `Chart` | Data shape differs: React `series`+`categories`, WC `series`+`labels`, RN single-series `data[]` |
+| User identity image | `Avatar` | — |
+| Icon by name | `Icon` | RN needs an explicit `color` prop (no CSS `currentColor`); React/WC inherit `currentColor` |
+| Keyboard-key hint | `Kbd` | — |
+| Flexible list-row primitive | `Item` | RN adds `onPress` (makes the row a button); React/WC have no press handling |
+| Highlighter over text | `Marker` | `variant`: default/success/info/danger |
+
+### Chat / messaging
+
+| Need | Component | Notes |
+|---|---|---|
+| Chat bubble | `Bubble` | `variant`: received/sent |
+| Chat message row | `Message` | `side`: received/sent |
+| Auto-stick-to-bottom chat log | `MessageScroller` | `stickToBottom`; WC also exposes an imperative `scrollToBottom()` |
+| File attachment chip | `Attachment` | React/RN use `onRemove` + `removeLabel`; WC uses a `removable` boolean + `gh-remove` event |
+
+## Reference
+
+- [rules/tokens.md](rules/tokens.md) — token consumption rules
+- [rules/accessibility.md](rules/accessibility.md) — ARIA, keyboard, focus management
+- [rules/composition.md](rules/composition.md) — component composition patterns
+- [rules/platform-differences.md](rules/platform-differences.md) — React / Web Components / React Native API differences
+- Full per-component prop tables and live demos: https://gyeonghokim.github.io/gyeongho-design-system/components/

--- a/.agents/skills/ghds/evals/evals.json
+++ b/.agents/skills/ghds/evals/evals.json
@@ -1,0 +1,86 @@
+{
+  "skill_name": "ghds",
+  "evals": [
+    {
+      "id": 1,
+      "prompt": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
+      "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
+      "files": [],
+      "expectations": [
+        "Uses the `heading` attribute on <gh-modal>, not `title`",
+        "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
+      ]
+    },
+    {
+      "id": 2,
+      "prompt": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
+      "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
+      "files": [],
+      "expectations": [
+        "Uses `onCheckedChange`, not `onChange`",
+        "The callback receives a bare boolean, not an event object"
+      ]
+    },
+    {
+      "id": 3,
+      "prompt": "Style a custom banner component to match our GHDS primary brand background and text color.",
+      "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
+      "files": [],
+      "expectations": [
+        "No hardcoded hex/rgb color values",
+        "References sys.* or comp.* tokens, not ref.* tokens"
+      ]
+    },
+    {
+      "id": 4,
+      "prompt": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
+      "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
+      "files": [],
+      "expectations": [
+        "Recommends or implements Toast, not Modal",
+        "Does not block user interaction or require an explicit dismiss action"
+      ]
+    },
+    {
+      "id": 5,
+      "prompt": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
+      "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
+      "files": [],
+      "expectations": [
+        "Uses FormField wrapping exactly one Input",
+        "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
+      ]
+    },
+    {
+      "id": 6,
+      "prompt": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
+      "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
+      "files": [],
+      "expectations": [
+        "Does not set variant=\"neutral\" on the React Native Button",
+        "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
+      ]
+    },
+    {
+      "id": 7,
+      "prompt": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
+      "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
+      "files": [],
+      "expectations": [
+        "Uses Skeleton for the initial load with no prior content",
+        "Uses Spinner for subsequent loads where content is already visible",
+        "Does not use Spinner for the first-paint case"
+      ]
+    },
+    {
+      "id": 8,
+      "prompt": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
+      "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
+      "files": [],
+      "expectations": [
+        "Applies a debounce (~300-400ms) before invoking the search/filter function",
+        "Does not call the search function synchronously on every onChange event"
+      ]
+    }
+  ]
+}

--- a/.agents/skills/ghds/rules/accessibility.md
+++ b/.agents/skills/ghds/rules/accessibility.md
@@ -1,0 +1,77 @@
+# Accessibility
+
+## Keyboard Interaction
+
+| Keys | Action |
+| --- | --- |
+| `Tab` | Move focus to the next focusable element in document order. |
+| `Shift + Tab` | Move focus to the previous focusable element. |
+| `Enter / Space` | Activate a focused Button. |
+| `Escape` | Close an open Modal (dismisses the dialog and restores focus to the trigger). Also dismisses Tooltip and Menu. |
+| `↑ ↓ ← →` | Navigate items within an open Menu (arrow keys), or cycle through Tabs (left/right arrows). |
+
+Most components (`Button`, `Card`, `Input`, `Alert`, `Badge`, `Avatar`, `Spinner`, `Progress`, `Skeleton`, `Table`) rely entirely on native browser keyboard handling — you don't need to add `onKeyDown`/`tabIndex` logic yourself. Overlay components (`Modal`, `Menu`, `Tooltip`) add their own bindings for dismissal and navigation. See `platform-differences.md` for where React Native's keyboard support falls short of this table.
+
+## ARIA Patterns by Component
+
+| Component | Pattern |
+| --- | --- |
+| `Button` | Native `<button>` role (or `aria-disabled` on the `asChild` path — see Focus Management below). |
+| `Card` | No role by default on React — you supply one. Web Components/React Native auto-expose `role="group"`/`accessibilityRole="summary"` when a `label` is given. |
+| `Input` | `aria-invalid` + `aria-describedby` (pointing at a `role="alert"` error message) wired automatically when used inside `FormField` with an `error` set. |
+| `Modal` | `role="dialog"` + `aria-modal="true"`, title wired via `aria-labelledby`. |
+| `Alert` | `role="status"` by default, `role="alert"` for the `danger` variant (assertive). |
+| `Toast` | `role="status"` (polite) for info/success/warning; `role="alert"` (assertive) for `danger`. |
+| `Tooltip` | `role="tooltip"`, trigger linked via `aria-describedby`. |
+| `Menu` | `role="menu"` with `role="menuitem"` on items; arrow-key navigation, Escape dismiss. |
+
+**Use `FormField` for error wiring instead of hand-rolling it.** `FormField` automatically wires `aria-describedby`/`aria-invalid` and gives the error text `role="alert"` — a hand-rolled error span next to an `Input` does not connect to it at all.
+
+```tsx
+// Incorrect — visually shows an error, but nothing wires it to the input for
+// screen readers; aria-invalid/aria-describedby are never set
+<Input error={hasError} />
+{hasError && <span className="error-text">Invalid email</span>}
+```
+
+```tsx
+// Correct — FormField wires aria-invalid + aria-describedby + role="alert"
+// automatically
+<FormField label="Email" error={hasError ? 'Invalid email' : undefined}>
+  <Input type="email" />
+</FormField>
+```
+
+## Focus Management
+
+- Always keep a visible focus ring — see `tokens.md`'s `comp.*.focus.ring` rule; never remove `outline` without replacing it.
+- A native `disabled` attribute removes an element from the tab order entirely. `Button`'s `asChild` path only sets `aria-disabled`, which does **not** remove it from the tab order — if you disable an `asChild` button, you must also prevent activation yourself.
+
+```tsx
+// Incorrect — assumes aria-disabled removes the element from the tab order (it
+// doesn't); a keyboard user can still Tab to and activate this "disabled" link
+<Button asChild disabled>
+  <a href="/checkout">Checkout</a>
+</Button>
+```
+
+```tsx
+// Correct — when using asChild, also guard activation manually, since
+// aria-disabled alone does not block Tab focus or Enter/Space activation
+<Button asChild aria-disabled={isDisabled}>
+  <a
+    href="/checkout"
+    onClick={(e) => { if (isDisabled) e.preventDefault(); }}
+    tabIndex={isDisabled ? -1 : undefined}
+  >
+    Checkout
+  </a>
+</Button>
+```
+
+- `Modal` and `Menu` trap focus while open and restore it to the triggering element on close.
+- `Toast` and `Tooltip` do **not** trap focus — they're transient/supplementary, so don't rely on them for a keyboard-only critical flow.
+
+## Color Contrast
+
+Every `sys.color.*` text/background pairing is validated at build time against WCAG 2.1 AA (4.5:1 for normal text, 3:1 for large text/icons/borders). This guarantee only holds when you consume `sys.*`/`comp.*` tokens — see `tokens.md` for the consumption rule this depends on.

--- a/.agents/skills/ghds/rules/composition.md
+++ b/.agents/skills/ghds/rules/composition.md
@@ -1,0 +1,131 @@
+# Composition Patterns
+
+GHDS components are deliberately small — most real UI is a *pattern*, a recipe combining several components. These are the recurring recipes and the decisions behind them.
+
+## FormField wraps exactly one control
+
+`FormField` composes a label, helper text, and error message around a **single** form control, wiring `id`/`aria-describedby`/`aria-invalid` to that one control. Wrapping more than one control breaks that wiring — only one of them ends up connected.
+
+```tsx
+// Incorrect — FormField composes around exactly one control; wrapping two
+// breaks its id/aria-describedby wiring
+<FormField label="Name">
+  <Input placeholder="First" />
+  <Input placeholder="Last" />
+</FormField>
+```
+
+```tsx
+// Correct — one FormField per control
+<FormField label="First name">
+  <Input />
+</FormField>
+<FormField label="Last name">
+  <Input />
+</FormField>
+```
+
+## Validate on blur + submit, not on every keystroke
+
+Validating on every keystroke is noisy and interrupts typing. Validate a field when it loses focus, and validate the whole form again on submit.
+
+```tsx
+// Incorrect — validates on every keystroke
+<Input onChange={(e) => { setValue(e.target.value); validate(e.target.value); }} />
+```
+
+```tsx
+// Correct — validate on blur (per-field), and again on submit (whole form)
+<Input
+  value={value}
+  onChange={(e) => setValue(e.target.value)}
+  onBlur={() => validate(value)}
+/>
+```
+
+Also: mark required fields with an asterisk or "(required)" text, not color alone. For forms with more than ~5 fields (or cross-field validation), prefer a summary `Alert variant="danger"` at the top over per-field inline errors alone.
+
+## Choosing between Toast, Alert, and Modal
+
+Decision tree:
+- User-initiated action, result stays on screen → **Alert** (inline, persistent).
+- User-initiated action, then the user navigates away → **Toast** (auto-dismiss).
+- System event that needs a decision → **Modal** (interrupts, traps focus).
+- System event, informational only → **Toast** (auto-dismiss).
+
+| | Toast | Alert | Modal |
+|---|---|---|---|
+| Position | Fixed, bottom-right | Inline, in layout | Centered overlay with scrim |
+| Persistence | Auto-dismiss (default 5s) | Stays until dismissed | Stays until explicit close |
+| Interrupts | No | No | Yes (traps focus, locks scroll) |
+| Requires action | No | Optional dismiss | Yes (at minimum "OK"/"Cancel") |
+| Use for | "Saved", "Copied" | Form errors, status banners | Confirmations, detail views |
+| Stacking | Multiple can stack | One per context | One at a time — never nested |
+
+```tsx
+// Incorrect — Modal for a simple success message; too heavy, interrupts the
+// user and forces a dismiss action for something that needed none
+<Modal open={saved} title="Success" onClose={() => setSaved(false)}>
+  Your changes were saved.
+</Modal>
+```
+
+```tsx
+// Correct — Toast for a transient, non-blocking confirmation
+<Toast variant="success" open={saved} onClose={() => setSaved(false)}>
+  Your changes were saved.
+</Toast>
+```
+
+Don't rely on color alone to convey severity — always pair the color token with an icon and text.
+
+## Choosing between Skeleton and Spinner
+
+| State | Trigger | Component |
+|---|---|---|
+| Loading (first paint) | Page/view mounts, fetch starts, nothing on screen yet | `Skeleton` |
+| Loading (subsequent) | Filter change, pagination, refresh — existing content stays visible | `Spinner` |
+| Empty | Zero results | Message + `Button` for a next action |
+| Error | Network/server failure | `Alert variant="danger"` + retry `Button` |
+
+Rule of thumb: is there existing content on screen? No → `Skeleton`. Yes → `Spinner`.
+
+```tsx
+// Incorrect — Spinner on first paint blanks the whole layout unnecessarily,
+// when there's no existing content to preserve context around
+function ProductList() {
+  if (loading) return <Spinner />;
+  return <List items={products} />;
+}
+```
+
+```tsx
+// Correct — Skeleton on first paint (mimics eventual layout); Spinner only for
+// subsequent loads where existing content stays visible
+function ProductList() {
+  if (isFirstLoad) return <Skeleton />;
+  return (
+    <>
+      {isRefetching && <Spinner />}
+      <List items={products} />
+    </>
+  );
+}
+```
+
+Use a live region (`role="status"`) to announce result counts (e.g. "Showing 12 of 45 items") — a `Spinner` alone isn't announced to screen readers.
+
+## Debounce search inputs
+
+Firing a search request on every keystroke hammers the backend unnecessarily.
+
+```tsx
+// Incorrect — fires a network request on every keystroke
+<Input onChange={(e) => search(e.target.value)} />
+```
+
+```tsx
+// Correct — debounce 300-400ms before firing
+const debouncedSearch = useMemo(() => debounce(search, 350), []);
+<Input onChange={(e) => debouncedSearch(e.target.value)} />
+```

--- a/.agents/skills/ghds/rules/platform-differences.md
+++ b/.agents/skills/ghds/rules/platform-differences.md
@@ -1,0 +1,139 @@
+# Platform Differences
+
+GHDS ships the same design as three separate implementations — `@ghds/react`, `@ghds/web-components` (Lit, `gh-*` custom elements), and `@ghds/react-native`. They are **not** a single API with three renderers; prop names, event shapes, and even the supported variant set diverge in specific, verified ways. Do not port a prop name from one platform to another without checking this file first.
+
+## Dialog family accessible title: `title` vs `heading`
+
+React and React Native use `title` for a dialog's accessible heading. Web Components uses `heading` for the identical concept. This applies to the **entire dialog family**, not just `Modal`: `Modal`, `AlertDialog`, `Drawer`, and `Sheet` all take `title` on React/React Native and `heading` on Web Components. (`Empty` — an empty-state placeholder, not a dialog — follows the same `title`→`heading` rename in Web Components.)
+
+```tsx
+// React / React Native
+<Modal title="Delete item?" open={open} onClose={onClose}>
+  ...
+</Modal>
+```
+
+```html
+<!-- Web Components — the prop is `heading`, not `title` -->
+<gh-modal heading="Delete item?" open>
+  ...
+</gh-modal>
+```
+
+**Gotcha:** `title` is also a native HTML global attribute (hover tooltip). Setting `title="Delete item?"` on `<gh-modal>` does not error — it silently renders a browser tooltip instead of wiring the dialog's accessible name. This is a wrong-behavior trap, not a compile-time catch.
+
+**Related:** `AlertDialog` also diverges on its variant model — React/React Native use a `destructive` boolean, while Web Components uses `variant: 'default' | 'danger'`. And `Drawer`/`Sheet` expose `closeOnScrimClick` on React and Web Components but **not** on React Native.
+
+## Change events: three different shapes
+
+- **React** — native `onChange(event)`; read `event.target.value` / `event.target.checked`.
+- **Web Components** — no callback prop at all; the element dispatches a native DOM `change`/`input` event, so the consumer must `addEventListener`.
+- **React Native** — differently-named callbacks that receive a bare value, not an event: `onCheckedChange?: (checked: boolean) => void` (`Checkbox`, `Switch`) and `onChangeText?: (text: string) => void` (`Input` — note the name, it is **not** `onChange`).
+
+```tsx
+// React
+<Checkbox onChange={(e) => setChecked(e.target.checked)} />
+<Input onChange={(e) => setValue(e.target.value)} />
+```
+
+```html
+<!-- Web Components -->
+<gh-checkbox id="my-checkbox"></gh-checkbox>
+<script>
+  document.getElementById('my-checkbox').addEventListener('change', (e) => {
+    console.log(e.target.checked);
+  });
+</script>
+```
+
+```tsx
+// React Native — NOT onChange
+<Checkbox onCheckedChange={(checked) => setChecked(checked)} />
+<Switch onCheckedChange={(checked) => setChecked(checked)} />
+<Input onChangeText={(text) => setValue(text)} />
+```
+
+## Button content: children vs `label`-only
+
+React and Web Components accept arbitrary children/slotted content. React Native's `Button` only accepts a `label: string` prop — there is no children slot, so rich or composed content (an icon plus text, for example) is not possible.
+
+```tsx
+// React / Web Components — arbitrary children
+<Button variant="primary"><Icon name="save" /> Save changes</Button>
+```
+
+```tsx
+// Incorrect on React Native — Button has no children prop
+<Button><Icon name="save" /> Save changes</Button>
+
+// Correct on React Native — label is a plain string
+<Button label="Save changes" variant="primary" />
+```
+
+## Button `variant`: React Native has no `'neutral'`
+
+React and Web Components support `'primary' | 'danger' | 'neutral'`. React Native's `ButtonVariant` is `'primary' | 'danger'` only — `'neutral'` does not exist there.
+
+```tsx
+// React / Web Components — three variants
+<Button variant="neutral">Cancel</Button>
+```
+
+```tsx
+// Incorrect on React Native — 'neutral' is not in the RN ButtonVariant union;
+// this is a type error, not a silent fallback
+<Button label="Cancel" variant="neutral" />
+
+// Correct on React Native — only 'primary' | 'danger' exist; use 'primary' with
+// custom styling, or a plain Pressable, for a neutral/tertiary action
+<Button label="Cancel" variant="primary" />
+```
+
+## React-Native-only props
+
+`testID` and `accessibilityHint` exist only on React Native — they have no equivalent prop on React or Web Components. When porting a component's usage from React/Web Components to React Native, add them where useful for testing/accessibility; when porting the other direction, drop them (they don't exist elsewhere and TypeScript will reject them on React/Web Components).
+
+## Web-Components-only: native form participation
+
+`Button`, `Checkbox`, and `Switch` on Web Components participate in native `<form>` submission and reset via `ElementInternals`/form-association — a real `<form>` submit or reset affects them automatically. React has no equivalent (plain DOM form semantics apply instead — you wire submission yourself), and React Native has no native `<form>` concept at all.
+
+## Selection groups: Web Components has no shared `value`
+
+`CheckboxGroup` and `RadioGroup` manage a shared selection on React and React Native — you read/write the group's state via `value` (a `string[]` for `CheckboxGroup`, a `string` for `RadioGroup`) plus `onValueChange`. **Web Components' group elements do not have `value`/`onValueChange` at all** — they are presentational (label, layout, disabled), and each child `gh-checkbox`/`gh-radio` owns its own `checked`/`value`. So on Web Components you wire state per-child and listen to each child's DOM event; there is no group-level callback.
+
+```tsx
+// React / React Native — group owns the shared value
+<CheckboxGroup value={selected} onValueChange={setSelected}>
+  <Checkbox value="a" /> <Checkbox value="b" />
+</CheckboxGroup>
+```
+
+```html
+<!-- Web Components — no group value; each child self-manages -->
+<gh-checkbox-group label="Pick some">
+  <gh-checkbox name="a"></gh-checkbox>
+  <gh-checkbox name="b"></gh-checkbox>
+</gh-checkbox-group>
+```
+
+## `orientation` union: React Native uses `'row' | 'column'`
+
+`ButtonGroup` and `ToggleGroup` accept an `orientation`, but the allowed string literals differ. React and Web Components use `'horizontal' | 'vertical'`; **React Native uses `'row' | 'column'`** (matching its flexbox naming). Porting `orientation="horizontal"` to React Native is a type error, not a silent fallback.
+
+Relatedly, `ToggleGroup`'s `value` typing differs: React types it by mode via a discriminated union (`string` when `type="single"`, `string[]` when `type="multiple"`), whereas React Native and Web Components always use `string[]` even in single-select mode.
+
+## `Separator` `decorative` default differs
+
+`Separator` takes a `decorative` boolean, but its default is not the same everywhere: **React Native defaults `decorative` to `true`** (the divider is hidden from assistive tech), while React and Web Components default it to `false` (exposed as `role="separator"`/`aria-orientation`). If a separator is semantically meaningful on React Native, set `decorative={false}` explicitly.
+
+## React Native touch adaptations: no hover / no right-click
+
+Components that open on hover or right-click on the web have no such gesture on React Native, so their RN API differs: `HoverCard` opens on **long-press**, `ContextMenu` opens on **long-press**, `Popover` opens on **press**, and `NavigationMenu` opens on **tap**. Each of these RN components therefore requires a `triggerLabel` (for the accessible pressable) and drops hover-specific props — `placement` and the `openDelay`/`closeDelay` family exist on React but not on React Native.
+
+## Accessibility prop gaps on React Native
+
+Three distinct situations — do not treat them as equivalent:
+
+- **`accessibilityValue` / `accessibilityState`** — these nested RN accessibility objects are not forwarded to the DOM by react-native-web. You do not need to work around this yourself: GHDS's React Native components already set the flat ARIA equivalent (`aria-checked`, `aria-valuenow`, etc.) internally alongside them, so the ARIA output a screen reader sees is correct in practice. This is mentioned only so you understand why passing these props yourself has no additional effect.
+- **`onAccessibilityAction`** — genuinely unsupported when a React Native app is rendered via react-native-web. It's currently exposed only on `Slider`. If you need a custom accessibility action on `Slider` in a web-rendered React Native context, there is no supported workaround today.
+- **Keyboard interaction (`onKeyDown`-based)** — not implemented for React Native at all. This is a real feature gap, not a forwarding issue: `Slider` has no arrow-key stepping on React Native, and `Tabs` has no roving-tabindex arrow-key navigation on React Native. If your product needs full keyboard parity between the web platforms and React Native, plan around this explicitly.

--- a/.agents/skills/ghds/rules/tokens.md
+++ b/.agents/skills/ghds/rules/tokens.md
@@ -1,0 +1,84 @@
+# Token Usage
+
+Every GHDS component reads its colors, spacing, typography, radii, and other design values from `@ghds/tokens`. Tokens come in three tiers — `ref` (raw values), `sys` (semantic roles), and `comp` (component-specific overrides). As a consumer, think of these as three layers you can reference in your own styles, not as files you edit — you only ever consume `sys.*` and `comp.*`.
+
+## Consume `sys.*`/`comp.*`, never `ref.*` or hardcoded values
+
+`ref` tokens are raw, unthemed primitives. Referencing them directly (or hardcoding a color/spacing value yourself) bypasses GHDS's semantic layer — your value won't respond to theme/dark-mode changes, and it loses the WCAG contrast guarantee that only holds for `sys.color.*`/`comp.*` pairings.
+
+```css
+/* Incorrect — hardcoded value, bypasses the contrast-validated token system */
+.my-button {
+  background-color: #0066cc;
+  color: #ffffff;
+}
+```
+
+```css
+/* Correct — consumes a sys token, contrast-guaranteed against its paired text/bg */
+.my-button {
+  background-color: var(--sys-color-bg-primary);
+  color: var(--sys-color-text-onPrimary);
+}
+```
+
+## Import the token stylesheet once, at app entry
+
+React and Web Components components read their values from CSS custom properties. Without importing the stylesheet, every color/spacing value silently falls back to unset.
+
+```tsx
+// Incorrect — no token stylesheet imported anywhere; every token-driven value
+// (color, spacing, radius) falls back to unset
+import { Button } from '@ghds/react/button';
+
+function Page() {
+  return <Button variant="primary">Save</Button>;
+}
+```
+
+```tsx
+// Correct — import once, at the app's root/entry file
+import '@ghds/tokens/css';
+import { Button } from '@ghds/react/button';
+
+function Page() {
+  return <Button variant="primary">Save</Button>;
+}
+```
+
+## React Native: tokens are a JS object, not CSS
+
+React Native has no stylesheet to import. Import the `tokens` object directly and reference the same `sys.*`/`comp.*` paths as JS property access:
+
+```tsx
+import { tokens } from '@ghds/tokens';
+import { StyleSheet } from 'react-native';
+
+const styles = StyleSheet.create({
+  button: {
+    backgroundColor: tokens.sys.color.bg.primary,
+    paddingHorizontal: tokens.sys.spacing.component.md,
+  },
+});
+```
+
+The rule is unchanged across platforms: reference `sys`/`comp`, never `ref`, never a literal value.
+
+## Prefer `comp.*` over `sys.*` when a component-specific token exists
+
+Some components — like focus rings — have their own dedicated `comp.*` token rather than a general `sys.*` one. Removing an outline without replacing it with the component's focus-ring token breaks visible-focus accessibility.
+
+```css
+/* Incorrect — removes the focus ring without replacing it */
+.my-input:focus {
+  outline: none;
+}
+```
+
+```css
+/* Correct — replaces it with the component's own focus-ring token */
+.my-input:focus {
+  outline: none;
+  box-shadow: 0 0 0 2px var(--comp-input-focus-ring);
+}
+```

--- a/.claude/skills/ghds
+++ b/.claude/skills/ghds
@@ -1,0 +1,1 @@
+../../.agents/skills/ghds

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,132 @@
+# Contributor Covenant Code of Conduct
+
+## Our Pledge
+
+We as members, contributors, and leaders pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age, body
+size, visible or invisible disability, ethnicity, sex characteristics, gender
+identity and expression, level of experience, education, socio-economic status,
+nationality, personal appearance, race, caste, color, religion, or sexual
+identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming,
+diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment for our
+community include:
+
+- Demonstrating empathy and kindness toward other people
+- Being respectful of differing opinions, viewpoints, and experiences
+- Giving and gracefully accepting constructive feedback
+- Accepting responsibility and apologizing to those affected by our mistakes,
+  and learning from the experience
+- Focusing on what is best not just for us as individuals, but for the overall
+  community
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or advances of
+  any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information, such as a physical or email address,
+  without their explicit permission
+- Other conduct which could reasonably be considered inappropriate in a
+  professional setting
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our standards of
+acceptable behavior and will take appropriate and fair corrective action in
+response to any behavior that they deem inappropriate, threatening, offensive,
+or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or reject
+comments, commits, code, wiki edits, issues, and other contributions that are
+not aligned to this Code of Conduct, and will communicate reasons for moderation
+decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces, and also applies when
+an individual is officially representing the community in public spaces.
+Examples of representing our community include using an official email address,
+posting via an official social media account, or acting as an appointed
+representative at an online or offline event.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported to the community leaders responsible for enforcement at
+[me@gyeongho.dev](mailto:me@gyeongho.dev).
+All complaints will be reviewed and investigated promptly and fairly.
+
+All community leaders are obligated to respect the privacy and security of the
+reporter of any incident.
+
+## Enforcement Guidelines
+
+Community leaders will follow these Community Impact Guidelines in determining
+the consequences for any action they deem in violation of this Code of Conduct:
+
+### 1. Correction
+
+**Community Impact**: Use of inappropriate language or other behavior deemed
+unprofessional or unwelcome in the community.
+
+**Consequence**: A private, written warning from community leaders, providing
+clarity around the nature of the violation and an explanation of why the
+behavior was inappropriate. A public apology may be requested.
+
+### 2. Warning
+
+**Community Impact**: A violation through a single incident or series of
+actions.
+
+**Consequence**: A warning with consequences for continued behavior. No
+interaction with the people involved, including unsolicited interaction with
+those enforcing the Code of Conduct, for a specified period of time. This
+includes avoiding interactions in community spaces as well as external channels
+like social media. Violating these terms may lead to a temporary or permanent
+ban.
+
+### 3. Temporary Ban
+
+**Community Impact**: A serious violation of community standards, including
+sustained inappropriate behavior.
+
+**Consequence**: A temporary ban from any sort of interaction or public
+communication with the community for a specified period of time. No public or
+private interaction with the people involved, including unsolicited interaction
+with those enforcing the Code of Conduct, is allowed during this period.
+Violating these terms may lead to a permanent ban.
+
+### 4. Permanent Ban
+
+**Community Impact**: Demonstrating a pattern of violation of community
+standards, including sustained inappropriate behavior, harassment of an
+individual, or aggression toward or disparagement of classes of individuals.
+
+**Consequence**: A permanent ban from any sort of public interaction within the
+community.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 2.1, available at
+[https://www.contributor-covenant.org/version/2/1/code_of_conduct.html][v2.1].
+
+Community Impact Guidelines were inspired by
+[Mozilla's code of conduct enforcement ladder][mozilla coc].
+
+For answers to common questions about this code of conduct, see the FAQ at
+[https://www.contributor-covenant.org/faq][faq]. Translations are available at
+[https://www.contributor-covenant.org/translations][translations].
+
+[homepage]: https://www.contributor-covenant.org
+[v2.1]: https://www.contributor-covenant.org/version/2/1/code_of_conduct.html
+[mozilla coc]: https://github.com/mozilla/diversity
+[faq]: https://www.contributor-covenant.org/faq
+[translations]: https://www.contributor-covenant.org/translations

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -82,5 +82,7 @@ that triggers a publish. The mechanics and the SemVer policy are documented in
 ## Code of conduct
 
 Be respectful and assume good intent. Harassment or abuse is not tolerated in
-issues, PRs, or Discussions. The maintainer may remove comments or block
-accounts that violate this.
+issues, PRs, or Discussions. The full policy — expected behavior, scope, and how
+to report and enforce violations — is in
+[`CODE_OF_CONDUCT.md`](./CODE_OF_CONDUCT.md) (Contributor Covenant 2.1). Report
+violations to [me@gyeongho.dev](mailto:me@gyeongho.dev).

--- a/README.md
+++ b/README.md
@@ -91,6 +91,14 @@ import '@fontsource/pretendard/700.css';
 See the [Fonts guide](https://gyeonghokim.github.io/gyeongho-design-system/fonts/) on the website
 for the full rationale and weight/payload guidance.
 
+## Contributing & Community
+
+- [Contributing Guide](./CONTRIBUTING.md) — how to set up, propose changes, and the Code Quality Gate
+- [Code of Conduct](./CODE_OF_CONDUCT.md) — Contributor Covenant; expected behavior and reporting
+- [Security Policy](./SECURITY.md) — how to report a vulnerability privately
+- [Governance](./GOVERNANCE.md) — how decisions are made and the component lifecycle
+- [Discussions](https://github.com/GyeongHoKim/gyeongho-design-system/discussions) — questions that aren't bugs or feature requests
+
 ## License
 
 [MIT](./LICENSE)

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,50 @@
+# Security Policy
+
+We take the security of GHDS and its published packages seriously. GHDS ships
+four packages to npm — `@ghds/tokens`, `@ghds/react`, `@ghds/web-components`,
+and `@ghds/react-native` — so a vulnerability here can reach every project that
+installs them. Thank you for helping keep the ecosystem safe.
+
+## Supported Versions
+
+Only the latest published minor of each `@ghds/*` package receives security
+fixes. Please upgrade to the newest release before reporting, in case the issue
+is already resolved.
+
+| Version | Supported |
+| --- | --- |
+| Latest release | ✅ |
+| Older releases | ❌ |
+
+## Reporting a Vulnerability
+
+**Please do not report security vulnerabilities through public GitHub issues,
+discussions, or pull requests.** Public disclosure before a fix is available
+puts every consumer at risk.
+
+Report privately through either channel:
+
+- **GitHub Private Vulnerability Reporting** — use the **"Report a
+  vulnerability"** button on the repository's
+  [Security tab](https://github.com/GyeongHoKim/gyeongho-design-system/security).
+  This keeps the report and discussion private until a fix ships.
+- **Email** — [me@gyeongho.dev](mailto:me@gyeongho.dev). Please use a subject
+  line beginning with `[SECURITY]`.
+
+Please include as much of the following as you can:
+
+- The affected package(s) and version(s)
+- The type of issue and its impact
+- Step-by-step reproduction (a minimal repro or proof of concept is ideal)
+- Any suggested mitigation, if known
+
+## What to Expect
+
+- **Acknowledgement** within 72 hours of your report.
+- An initial assessment and, if accepted, a rough remediation timeline.
+- Progress updates as a fix is developed, and coordination on a disclosure date.
+- Credit for the reporter in the release notes once the fix is published, unless
+  you prefer to remain anonymous.
+
+We ask that you give us a reasonable window to release a fix before any public
+disclosure.

--- a/skills-lock.json
+++ b/skills-lock.json
@@ -1,0 +1,11 @@
+{
+  "version": 1,
+  "skills": {
+    "ghds": {
+      "source": "GyeongHoKim/gyeongho-design-system",
+      "sourceType": "github",
+      "skillPath": "skills/ghds/SKILL.md",
+      "computedHash": "75bc4462806dc3f2b4959bb3db74a44aa96ab3fbb5f59571f03e9f59d122f04c"
+    }
+  }
+}

--- a/skills/ghds/evals/evals.json
+++ b/skills/ghds/evals/evals.json
@@ -1,86 +1,91 @@
-{
-  "skill_name": "ghds",
-  "evals": [
-    {
-      "id": 1,
-      "prompt": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
-      "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
-      "files": [],
-      "expectations": [
-        "Uses the `heading` attribute on <gh-modal>, not `title`",
-        "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
-      ]
-    },
-    {
-      "id": 2,
-      "prompt": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
-      "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
-      "files": [],
-      "expectations": [
-        "Uses `onCheckedChange`, not `onChange`",
-        "The callback receives a bare boolean, not an event object"
-      ]
-    },
-    {
-      "id": 3,
-      "prompt": "Style a custom banner component to match our GHDS primary brand background and text color.",
-      "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
-      "files": [],
-      "expectations": [
-        "No hardcoded hex/rgb color values",
-        "References sys.* or comp.* tokens, not ref.* tokens"
-      ]
-    },
-    {
-      "id": 4,
-      "prompt": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
-      "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
-      "files": [],
-      "expectations": [
-        "Recommends or implements Toast, not Modal",
-        "Does not block user interaction or require an explicit dismiss action"
-      ]
-    },
-    {
-      "id": 5,
-      "prompt": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
-      "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
-      "files": [],
-      "expectations": [
-        "Uses FormField wrapping exactly one Input",
-        "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
-      ]
-    },
-    {
-      "id": 6,
-      "prompt": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
-      "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
-      "files": [],
-      "expectations": [
-        "Does not set variant=\"neutral\" on the React Native Button",
-        "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
-      ]
-    },
-    {
-      "id": 7,
-      "prompt": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
-      "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
-      "files": [],
-      "expectations": [
-        "Uses Skeleton for the initial load with no prior content",
-        "Uses Spinner for subsequent loads where content is already visible",
-        "Does not use Spinner for the first-paint case"
-      ]
-    },
-    {
-      "id": 8,
-      "prompt": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
-      "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
-      "files": [],
-      "expectations": [
-        "Applies a debounce (~300-400ms) before invoking the search/filter function",
-        "Does not call the search function synchronously on every onChange event"
-      ]
-    }
-  ]
-}
+[
+  {
+    "id": 1,
+    "skills": ["ghds"],
+    "query": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
+    "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
+    "files": [],
+    "expected_behavior": [
+      "Uses the `heading` attribute on <gh-modal>, not `title`",
+      "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
+    ]
+  },
+  {
+    "id": 2,
+    "skills": ["ghds"],
+    "query": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
+    "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
+    "files": [],
+    "expected_behavior": [
+      "Uses `onCheckedChange`, not `onChange`",
+      "The callback receives a bare boolean, not an event object"
+    ]
+  },
+  {
+    "id": 3,
+    "skills": ["ghds"],
+    "query": "Style a custom banner component to match our GHDS primary brand background and text color.",
+    "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
+    "files": [],
+    "expected_behavior": [
+      "No hardcoded hex/rgb color values",
+      "References sys.* or comp.* tokens, not ref.* tokens"
+    ]
+  },
+  {
+    "id": 4,
+    "skills": ["ghds"],
+    "query": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
+    "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
+    "files": [],
+    "expected_behavior": [
+      "Recommends or implements Toast, not Modal",
+      "Does not block user interaction or require an explicit dismiss action"
+    ]
+  },
+  {
+    "id": 5,
+    "skills": ["ghds"],
+    "query": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
+    "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
+    "files": [],
+    "expected_behavior": [
+      "Uses FormField wrapping exactly one Input",
+      "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
+    ]
+  },
+  {
+    "id": 6,
+    "skills": ["ghds"],
+    "query": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
+    "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
+    "files": [],
+    "expected_behavior": [
+      "Does not set variant=\"neutral\" on the React Native Button",
+      "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
+    ]
+  },
+  {
+    "id": 7,
+    "skills": ["ghds"],
+    "query": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
+    "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
+    "files": [],
+    "expected_behavior": [
+      "Uses Skeleton for the initial load with no prior content",
+      "Uses Spinner for subsequent loads where content is already visible",
+      "Does not use Spinner for the first-paint case"
+    ]
+  },
+  {
+    "id": 8,
+    "skills": ["ghds"],
+    "query": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
+    "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
+    "files": [],
+    "expected_behavior": [
+      "Applies a debounce (~300-400ms) before invoking the search/filter function",
+      "Does not call the search function synchronously on every onChange event"
+    ]
+  }
+]

--- a/skills/ghds/rules/composition.md
+++ b/skills/ghds/rules/composition.md
@@ -2,6 +2,14 @@
 
 GHDS components are deliberately small — most real UI is a *pattern*, a recipe combining several components. These are the recurring recipes and the decisions behind them.
 
+## Contents
+
+- FormField wraps exactly one control
+- Validate on blur + submit, not on every keystroke
+- Choosing between Toast, Alert, and Modal
+- Choosing between Skeleton and Spinner
+- Debounce search inputs
+
 ## FormField wraps exactly one control
 
 `FormField` composes a label, helper text, and error message around a **single** form control, wiring `id`/`aria-describedby`/`aria-invalid` to that one control. Wrapping more than one control breaks that wiring — only one of them ends up connected.

--- a/skills/ghds/rules/platform-differences.md
+++ b/skills/ghds/rules/platform-differences.md
@@ -2,6 +2,20 @@
 
 GHDS ships the same design as three separate implementations — `@ghds/react`, `@ghds/web-components` (Lit, `gh-*` custom elements), and `@ghds/react-native`. They are **not** a single API with three renderers; prop names, event shapes, and even the supported variant set diverge in specific, verified ways. Do not port a prop name from one platform to another without checking this file first.
 
+## Contents
+
+- Dialog family accessible title: `title` vs `heading`
+- Change events: three different shapes
+- Button content: children vs `label`-only
+- Button `variant`: React Native has no `'neutral'`
+- React-Native-only props
+- Web-Components-only: native form participation
+- Selection groups: Web Components has no shared `value`
+- `orientation` union: React Native uses `'row' | 'column'`
+- `Separator` `decorative` default differs
+- React Native touch adaptations: no hover / no right-click
+- Accessibility prop gaps on React Native
+
 ## Dialog family accessible title: `title` vs `heading`
 
 React and React Native use `title` for a dialog's accessible heading. Web Components uses `heading` for the identical concept. This applies to the **entire dialog family**, not just `Modal`: `Modal`, `AlertDialog`, `Drawer`, and `Sheet` all take `title` on React/React Native and `heading` on Web Components. (`Empty` — an empty-state placeholder, not a dialog — follows the same `title`→`heading` rename in Web Components.)


### PR DESCRIPTION
## Summary

이 PR은 저장소의 커뮤니티 표준과 에이전트 스킬을 보완합니다.

- **ghds agent skills 추가** (`.agents/skills/ghds`, `skills/ghds`): SKILL.md, evals, 규칙 파일(accessibility, composition, platform-differences, tokens)을 추가하고 `skills-lock.json`을 갱신했습니다.
- **Code of Conduct & Security Policy**: `CODE_OF_CONDUCT.md`(Contributor Covenant 2.1), `SECURITY.md`(비공개 취약점 신고 절차, 지원 버전, 대응 기대치)를 추가했고 `GOVERNANCE.md`가 이를 참조하도록 변경했습니다.
- **README**: Contributing & Community 섹션을 추가해 관련 문서를 연결했습니다.
- **Agent Skills 표준 정렬**: `evals.json` 필드명을 표준 스키마(`prompt`→`query`, `expectations`→`expected_behavior`)로 갱신하고, 100줄 이상 참조 파일에 목차를 추가했습니다.

## Test plan

- [x] `pnpm check` 통과 (lint + format)
- [x] 워킹 트리 클린, 커밋 3개 정리됨

🤖 Generated with [opencode](https://opencode.ai)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive GHDS guidance covering design tokens, accessibility, composition patterns, platform differences, forms, feedback, loading states, and search behavior.
  * Added cross-platform component usage references and evaluation examples.
  * Added contributor, governance, code of conduct, and security policy documentation.
  * Improved README navigation to community resources.
  * Added documentation contents sections for easier navigation.

* **Chores**
  * Standardized GHDS skill configuration and synchronization metadata.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->