### PR TITLE
feat(repo): categorized dropdown header nav via gh-navigation-menu

### DIFF
--- a/.agents/skills/ghds/rules/platform-differences.md
+++ b/.agents/skills/ghds/rules/platform-differences.md
@@ -114,6 +114,15 @@ React Native has neither — navigation there is a `Button`/`Pressable` with an 
 
 `Button`, `Checkbox`, and `Switch` on Web Components participate in native `<form>` submission and reset via `ElementInternals`/form-association — a real `<form>` submit or reset affects them automatically. React has no equivalent (plain DOM form semantics apply instead — you wire submission yourself), and React Native has no native `<form>` concept at all.
 
+## Web-Components-only: `gh-navigation-menu` `current`
+
+`gh-navigation-menu` on Web Components takes a `current` property (the active page's path) and highlights the matching item itself: a standalone link matches its path exactly, a dropdown group lights up when a child is the current page or an ancestor of it, and the exact leaf link gets `aria-current="page"`. React and React Native `NavigationMenu` have no `current` prop — mark the active route yourself (React is href-based, so compare against the router location; React Native is selection-callback based, so track the active `value`).
+
+```tsx
+// Web Components — the element resolves the highlight from the path.
+<gh-navigation-menu .items=${items} current="/en/components/button"></gh-navigation-menu>
+```
+
 ## Selection groups: Web Components has no shared `value`
 
 `CheckboxGroup` and `RadioGroup` manage a shared selection on React and React Native — you read/write the group's state via `value` (a `string[]` for `CheckboxGroup`, a `string` for `RadioGroup`) plus `onValueChange`. **Web Components' group elements do not have `value`/`onValueChange` at all** — they are presentational (label, layout, disabled), and each child `gh-checkbox`/`gh-radio` owns its own `checked`/`value`. So on Web Components you wire state per-child and listen to each child's DOM event; there is no group-level callback.

--- a/.changeset/gh-navigation-menu-current.md
+++ b/.changeset/gh-navigation-menu-current.md
@@ -1,0 +1,5 @@
+---
+"@ghds/web-components": minor
+---
+
+`gh-navigation-menu` now accepts a `current` property — the active page's path — and highlights the matching item. A standalone top-level link matches its path exactly (so a root `/` link is current only on the home page); a dropdown group is highlighted when any of its child links matches the current path exactly *or* as an ancestor (`/components/` is current on `/components/button/`). Matching leaf links receive `aria-current="page"`. Trailing slashes and query/hash are ignored when comparing. Leaving `current` unset preserves the previous behaviour (nothing highlighted).

--- a/apps/website/src/layouts/BaseLayout.astro
+++ b/apps/website/src/layouts/BaseLayout.astro
@@ -17,9 +17,10 @@ import '@fontsource/pretendard/400.css';
 import '@fontsource/pretendard/500.css';
 import '@fontsource/pretendard/700.css';
 import '../styles/global.css';
+import type { GhNavigationItem } from '@ghds/web-components/navigation-menu';
 import type { Locale } from '../i18n/ui';
 import { UI } from '../i18n/ui';
-import { NAV } from '../lib/nav';
+import { NAV_CATEGORIES } from '../lib/nav';
 import { setLocale, withBase } from '../lib/withBase';
 
 interface Props {
@@ -39,19 +40,23 @@ setLocale(locale);
 const ui = UI[locale];
 
 const normalize = (path: string): string => path.replace(/\/+$/, '') || '/';
-const here = normalize(Astro.url.pathname);
+// The current path (base + locale aware); `gh-navigation-menu` resolves which
+// item to highlight from this. `withBase` produces matching base-aware hrefs.
+const currentPath = normalize(Astro.url.pathname);
 
-// A link is current on its own page and any nested route beneath it. The home
-// link ('/') matches only the home page, so Getting Started is no longer wrongly active.
-// `here` includes the configured base path, so compare against base-aware hrefs.
-const home = normalize(withBase('/'));
-function isCurrent(href: string): boolean {
-  const target = normalize(withBase(href));
-  if (target === home) {
-    return here === home;
-  }
-  return here === target || here.startsWith(`${target}/`);
-}
+// The header IA: categories → base-aware nav items for <gh-navigation-menu>.
+// Direct links carry an href; categories carry children whose per-section
+// `summary` becomes the dropdown description.
+const navLabel = locale === 'ko' ? '주요 내비게이션' : 'Main navigation';
+const navItems: GhNavigationItem[] = NAV_CATEGORIES.map((category) => ({
+  label: category.label[locale],
+  href: category.href ? withBase(category.href) : undefined,
+  children: category.children?.map((child) => ({
+    label: child.label[locale],
+    href: withBase(child.href),
+    description: child.summary[locale],
+  })),
+}));
 
 // Language switcher: build the equivalent URL in the other locale.
 function switchLocaleHref(target: Locale): string {
@@ -93,16 +98,7 @@ function switchLocaleHref(target: Locale): string {
       <a class="brand" href={withBase('/')}>
         {ui.brand} <small>{ui.brandSubtitle}</small>
       </a>
-      <nav class="site-nav" aria-label={locale === 'ko' ? '주요 내비게이션' : 'Main navigation'}>
-        <a href={withBase('/')} aria-current={isCurrent('/') ? 'page' : undefined}>{ui.home}</a>
-        {
-          NAV.map((item) => (
-            <a href={withBase(item.href)} aria-current={isCurrent(item.href) ? 'page' : undefined}>
-              {item.label[locale]}
-            </a>
-          ))
-        }
-      </nav>
+      <gh-navigation-menu id="site-nav" class="site-nav" label={navLabel}></gh-navigation-menu>
       <div class="header-actions">
         <gh-button
           variant="neutral"
@@ -128,6 +124,19 @@ function switchLocaleHref(target: Locale): string {
 
     <script>
       import '@ghds/web-components/button';
+      import '@ghds/web-components/navigation-menu';
+    </script>
+
+    {/* Feed the nav its items/current as JS properties (arrays can't be set via
+        attributes). Lit re-applies instance properties set before the element
+        upgrades, so ordering against the registration script above is safe. */}
+    <script define:vars={{ navItems, navLabel, currentPath }}>
+      const nav = document.getElementById('site-nav');
+      if (nav) {
+        nav.items = navItems;
+        nav.label = navLabel;
+        nav.current = currentPath;
+      }
     </script>
 
     <script>

--- a/apps/website/src/lib/nav.ts
+++ b/apps/website/src/lib/nav.ts
@@ -100,3 +100,52 @@ export const NAV: readonly NavItem[] = [
     },
   },
 ];
+
+/**
+ * A top-level entry in the site header: either a direct link (`href`, no
+ * dropdown) or a category that opens a dropdown of its `children`.
+ */
+export interface NavCategory {
+  /** Localized top-level label. */
+  readonly label: Record<Locale, string>;
+  /** Route path for a direct (childless) link. */
+  readonly href?: string;
+  /** Sub-links shown in the dropdown panel (reuse the flat {@link NAV} items). */
+  readonly children?: readonly NavItem[];
+}
+
+/** Look up a flat NAV entry by href so categories reuse a single source. */
+function byHref(href: string): NavItem {
+  const item = NAV.find((entry) => entry.href === href);
+  if (!item) {
+    throw new Error(`NAV has no entry for "${href}"`);
+  }
+  return item;
+}
+
+/**
+ * The header's information architecture: the eleven flat {@link NAV} sections
+ * grouped into a compact set of top-level entries so the nav fits one row and
+ * exposes categorized dropdowns. `Home` and `Resources` are direct links; the
+ * rest open dropdown panels. Child summaries become the dropdown descriptions.
+ */
+export const NAV_CATEGORIES: readonly NavCategory[] = [
+  { label: { en: 'Home', ko: '홈' }, href: '/' },
+  {
+    label: { en: 'Start', ko: '시작' },
+    children: [byHref('/getting-started/'), byHref('/skills/')],
+  },
+  {
+    label: { en: 'Foundations', ko: '파운데이션' },
+    children: [byHref('/fonts/'), byHref('/design-style/'), byHref('/foundations/')],
+  },
+  {
+    label: { en: 'Library', ko: '라이브러리' },
+    children: [byHref('/components/'), byHref('/patterns/')],
+  },
+  {
+    label: { en: 'Guidelines', ko: '가이드라인' },
+    children: [byHref('/principles/'), byHref('/ux-writing/'), byHref('/about/')],
+  },
+  { label: byHref('/resources/').label, href: '/resources/' },
+];

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -121,28 +121,16 @@ code {
   color: var(--sys-color-text-secondary);
 }
 
+/* The nav is a <gh-navigation-menu> custom element; it owns its own item,
+   hover, dropdown, and current-page styling in shadow DOM (from
+   comp.navigationMenu.* tokens). Here we only place it in the header: let it
+   take the middle space and scroll horizontally on very narrow viewports
+   instead of forcing the header to wrap. */
 .site-nav {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: var(--sys-spacing-xs);
-}
-
-.site-nav a {
-  color: var(--sys-color-text-secondary);
-  padding: var(--sys-spacing-xs) var(--sys-spacing-sm);
-  border-radius: var(--sys-radius-md);
-  font-size: var(--sys-typography-label-fontSize);
-}
-
-.site-nav a:hover {
-  background-color: var(--sys-color-bg-muted);
-  text-decoration: none;
-}
-
-.site-nav a[aria-current="page"] {
-  color: var(--sys-color-text-onPrimary);
-  background-color: var(--sys-color-bg-primary-default);
+  flex: 1 1 auto;
+  min-width: 0;
+  max-width: 100%;
+  overflow-x: auto;
 }
 
 /* Theme toggle is now a <gh-button variant="neutral"> — styled by the

--- a/packages/web-components/src/components/navigation-menu.ts
+++ b/packages/web-components/src/components/navigation-menu.ts
@@ -4,6 +4,7 @@ import { rectangle } from '@ghds/sketch-core';
 import { tokens } from '@ghds/tokens';
 import { css, html, nothing } from 'lit';
 import { customElement, property, query, state } from 'lit/decorators.js';
+import { classMap } from 'lit/directives/class-map.js';
 import { type SketchParams, SketchyBase } from '../sketchy-base.js';
 
 /** A leaf navigation link. */
@@ -30,6 +31,13 @@ let navigationMenuUid = 0;
  * `@floating-ui/dom` and drawn as a sketchy, solid box (`@ghds/sketch-core`).
  * Arrow Left/Right rove the top-level items, Escape closes. Colours and sketch
  * parameters come from `@ghds/tokens` (`comp.navigationMenu.*`).
+ *
+ * Set `current` to the active page's path to highlight the matching item. A
+ * standalone top-level link matches its path exactly (so a root `/` link is
+ * current only on the home page); a dropdown group is highlighted when any of
+ * its child links matches the current path exactly *or* as an ancestor
+ * (`/components/` is current on `/components/button/`). A leaf link is given
+ * `aria-current="page"` only on an exact match.
  */
 @customElement('gh-navigation-menu')
 export class GhNavigationMenu extends SketchyBase {
@@ -71,6 +79,12 @@ export class GhNavigationMenu extends SketchyBase {
 
       .top:hover {
         background: var(--comp-navigationMenu-item-hover);
+      }
+
+      .top.current {
+        color: var(--comp-navigationMenu-text-active);
+        text-decoration: underline;
+        text-underline-offset: var(--sys-spacing-xs);
       }
 
       .top:focus-visible {
@@ -117,6 +131,11 @@ export class GhNavigationMenu extends SketchyBase {
         color: var(--comp-navigationMenu-text-active);
       }
 
+      .link[aria-current='page'] {
+        color: var(--comp-navigationMenu-text-active);
+        font-weight: var(--sys-typography-label-fontWeight);
+      }
+
       .link .desc {
         color: var(--sys-color-text-secondary);
         font-size: var(--sys-typography-caption-fontSize);
@@ -133,6 +152,8 @@ export class GhNavigationMenu extends SketchyBase {
   @property({ attribute: false }) items: GhNavigationItem[] = [];
   /** Accessible label for the navigation region. */
   @property({ type: String }) label = '';
+  /** The active page's path; highlights the matching item (see class docs). */
+  @property({ type: String }) current = '';
 
   @state() private activeIndex = -1;
 
@@ -144,6 +165,40 @@ export class GhNavigationMenu extends SketchyBase {
 
   protected override get frame(): HTMLElement {
     return this.panelEl ?? this;
+  }
+
+  /** Strip query/hash and trailing slashes so paths compare cleanly. */
+  private normalizePath(path: string): string {
+    return path.replace(/[?#].*$/, '').replace(/\/+$/, '') || '/';
+  }
+
+  /** True when `href` is exactly the current path (the "this page" test). */
+  private isExactCurrent(href: string | undefined): boolean {
+    if (!this.current || !href) {
+      return false;
+    }
+    return this.normalizePath(this.current) === this.normalizePath(href);
+  }
+
+  /** True when the current path is `href` or a descendant of it. */
+  private containsCurrent(href: string | undefined): boolean {
+    if (!this.current || !href) {
+      return false;
+    }
+    const cur = this.normalizePath(this.current);
+    const base = this.normalizePath(href);
+    return cur === base || cur.startsWith(`${base}/`);
+  }
+
+  /**
+   * Whether a top-level item is highlighted: a group lights up when any child
+   * contains the current path; a standalone link only on an exact match.
+   */
+  private isItemCurrent(item: GhNavigationItem): boolean {
+    if (item.children && item.children.length > 0) {
+      return item.children.some((child) => this.containsCurrent(child.href));
+    }
+    return this.isExactCurrent(item.href);
   }
 
   override disconnectedCallback(): void {
@@ -227,10 +282,11 @@ export class GhNavigationMenu extends SketchyBase {
     return html`<nav aria-label=${this.label || nothing} @keydown=${this.onKeydown}>
       <ul class="list">
         ${this.items.map((item, index) => {
+          const current = this.isItemCurrent(item);
           if (item.children && item.children.length > 0) {
             return html`<li>
               <button
-                class="top"
+                class=${classMap({ top: true, current })}
                 type="button"
                 aria-haspopup="true"
                 aria-expanded=${this.activeIndex === index ? 'true' : 'false'}
@@ -246,7 +302,11 @@ export class GhNavigationMenu extends SketchyBase {
             </li>`;
           }
           return html`<li>
-            <a class="top" href=${item.href ?? '#'} @mouseenter=${() => this.close()}
+            <a
+              class=${classMap({ top: true, current })}
+              href=${item.href ?? '#'}
+              aria-current=${current ? 'page' : nothing}
+              @mouseenter=${() => this.close()}
               >${item.label}</a
             >
           </li>`;
@@ -261,7 +321,12 @@ export class GhNavigationMenu extends SketchyBase {
         ${this.renderSketch()}
         <div class="links">
           ${(active?.children ?? []).map(
-            (link) => html`<a class="link" role="menuitem" href=${link.href}>
+            (link) => html`<a
+              class="link"
+              role="menuitem"
+              href=${link.href}
+              aria-current=${this.isExactCurrent(link.href) ? 'page' : nothing}
+            >
               <span>${link.label}</span>
               ${link.description ? html`<span class="desc">${link.description}</span>` : nothing}
             </a>`,

--- a/packages/web-components/src/test/navigation-menu.test.ts
+++ b/packages/web-components/src/test/navigation-menu.test.ts
@@ -46,4 +46,64 @@ describe('gh-navigation-menu', () => {
     expect(links?.length).toBe(2);
     expect(links?.[0]?.getAttribute('href')).toBe('/web');
   });
+
+  describe('current-page highlighting', () => {
+    it('marks a standalone link current only on an exact path match', async () => {
+      const el = await mountNav();
+      el.current = '/';
+      await el.updateComplete;
+      const home = el.shadowRoot?.querySelector('a.top');
+      expect(home?.classList.contains('current')).toBe(true);
+      expect(home?.getAttribute('aria-current')).toBe('page');
+    });
+
+    it('does not mark a root link current on a descendant page', async () => {
+      const el = await mountNav();
+      el.current = '/web';
+      await el.updateComplete;
+      const home = el.shadowRoot?.querySelector('a.top');
+      expect(home?.classList.contains('current')).toBe(false);
+      expect(home?.getAttribute('aria-current')).toBeNull();
+    });
+
+    it('highlights a dropdown group when a child is an ancestor of the current path', async () => {
+      const el = await mount(new GhNavigationMenu());
+      el.items = [
+        { label: 'Home', href: '/' },
+        { label: 'Library', children: [{ label: 'Components', href: '/components' }] },
+      ];
+      el.current = '/components/button';
+      await el.updateComplete;
+      expect(el.shadowRoot?.querySelector('button.top')?.classList.contains('current')).toBe(true);
+      // The root link stays un-highlighted even though the path starts with '/'.
+      expect(el.shadowRoot?.querySelector('a.top')?.classList.contains('current')).toBe(false);
+    });
+
+    it('sets aria-current="page" on a leaf link only on an exact match', async () => {
+      const el = await mountNav();
+      el.current = '/web';
+      await el.updateComplete;
+      (el.shadowRoot?.querySelector('button.top') as HTMLButtonElement).click();
+      await el.updateComplete;
+      const links = el.shadowRoot?.querySelectorAll('.panel .link');
+      expect(links?.[0]?.getAttribute('aria-current')).toBe('page'); // /web
+      expect(links?.[1]?.getAttribute('aria-current')).toBeNull(); // /mobile
+    });
+
+    it('ignores a trailing slash when matching', async () => {
+      const el = await mountNav();
+      el.current = '/mobile/';
+      await el.updateComplete;
+      (el.shadowRoot?.querySelector('button.top') as HTMLButtonElement).click();
+      await el.updateComplete;
+      const links = el.shadowRoot?.querySelectorAll('.panel .link');
+      expect(links?.[1]?.getAttribute('aria-current')).toBe('page'); // /mobile matches /mobile/
+    });
+
+    it('highlights nothing when current is unset', async () => {
+      const el = await mountNav();
+      expect(el.shadowRoot?.querySelector('a.top')?.classList.contains('current')).toBe(false);
+      expect(el.shadowRoot?.querySelector('button.top')?.classList.contains('current')).toBe(false);
+    });
+  });
 });


### PR DESCRIPTION
The docs-site header hand-rolled a flat row of 12 `<a>` links that wrapped to two lines on narrow widths. Replace it with the purpose-built GHDS `gh-navigation-menu`, grouped into 6 top-level entries with categorized dropdowns.

### Changes
- **`gh-navigation-menu` gains a `current` property.** It resolves which item to highlight from the active path: a standalone link matches exactly (root `/` is current only on home); a dropdown group lights up when a child is the current page or an ancestor of it (`/components/` → current on `/components/button/`); the exact leaf gets `aria-current="page"`. Trailing slash / query / hash are ignored. Adds tests, a changeset, and a platform-differences note (WC-only prop; React/RN mark the active route themselves).
- **`lib/nav.ts` adds `NAV_CATEGORIES`** — the eleven flat `NAV` sections grouped into Home / Start / Foundations / Library / Guidelines / Resources, reusing the same `NAV` entries (their summaries become dropdown descriptions). Flat `NAV` is untouched so the home Explore grid keeps working.
- **`BaseLayout` renders `<gh-navigation-menu>`**, feeding `items`/`current` as JS properties via a `define:vars` script (arrays can't be attributes). The flat `isCurrent` logic and dead `.site-nav a` CSS are removed. The nav takes the header's middle space and scrolls horizontally on very narrow viewports instead of wrapping. Shell stays React-free (web component, no island).

### Verification
Driven in a real browser (Playwright): desktop header is one row of 6 items; the Library dropdown opens with Components/Patterns + descriptions; Library shows the current-page underline on `/components/button/`. website build (110 pages), `check-types`, biome, website tests (5) + web-components tests (407, incl. 6 new nav tests) — all green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)