### PR TITLE
feat: runtime theming via CSS-variable reference chains + playground

### DIFF
--- a/.agents/skills/ghds/SKILL.md
+++ b/.agents/skills/ghds/SKILL.md
@@ -42,6 +42,7 @@ import { tokens } from '@ghds/tokens';
 Each rule below is enforced — follow the link for the full Incorrect/Correct code pairs.
 
 - **[Token usage](rules/tokens.md)** — always consume `sys.*`/`comp.*` tokens, never `ref.*` directly or a hardcoded value.
+- **[Theming](rules/theming.md)** — rebrand by overriding `--sys-*` CSS custom properties (they cascade to every component), never by hardcoding brand colors or forking components; always cover dark mode.
 - **[Accessibility](rules/accessibility.md)** — ARIA patterns, keyboard interaction, and focus management per component.
 - **[Composition](rules/composition.md)** — `FormField` wraps exactly one control; choosing between Toast/Alert/Modal and Skeleton/Spinner; debounce search inputs.
 - **[Platform differences](rules/platform-differences.md)** — prop and event naming diverges across React / Web Components / React Native. Never port a prop name from one platform to another without checking this file.
@@ -180,6 +181,7 @@ All components below exist on all three platforms (`@ghds/react`, `@ghds/web-com
 ## Reference
 
 - [rules/tokens.md](rules/tokens.md) — token consumption rules
+- [rules/theming.md](rules/theming.md) — rebranding/customization via CSS-variable overrides
 - [rules/accessibility.md](rules/accessibility.md) — ARIA, keyboard, focus management
 - [rules/composition.md](rules/composition.md) — component composition patterns
 - [rules/platform-differences.md](rules/platform-differences.md) — React / Web Components / React Native API differences

--- a/.agents/skills/ghds/evals/evals.json
+++ b/.agents/skills/ghds/evals/evals.json
@@ -1,86 +1,91 @@
-{
-  "skill_name": "ghds",
-  "evals": [
-    {
-      "id": 1,
-      "prompt": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
-      "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
-      "files": [],
-      "expectations": [
-        "Uses the `heading` attribute on <gh-modal>, not `title`",
-        "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
-      ]
-    },
-    {
-      "id": 2,
-      "prompt": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
-      "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
-      "files": [],
-      "expectations": [
-        "Uses `onCheckedChange`, not `onChange`",
-        "The callback receives a bare boolean, not an event object"
-      ]
-    },
-    {
-      "id": 3,
-      "prompt": "Style a custom banner component to match our GHDS primary brand background and text color.",
-      "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
-      "files": [],
-      "expectations": [
-        "No hardcoded hex/rgb color values",
-        "References sys.* or comp.* tokens, not ref.* tokens"
-      ]
-    },
-    {
-      "id": 4,
-      "prompt": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
-      "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
-      "files": [],
-      "expectations": [
-        "Recommends or implements Toast, not Modal",
-        "Does not block user interaction or require an explicit dismiss action"
-      ]
-    },
-    {
-      "id": 5,
-      "prompt": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
-      "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
-      "files": [],
-      "expectations": [
-        "Uses FormField wrapping exactly one Input",
-        "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
-      ]
-    },
-    {
-      "id": 6,
-      "prompt": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
-      "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
-      "files": [],
-      "expectations": [
-        "Does not set variant=\"neutral\" on the React Native Button",
-        "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
-      ]
-    },
-    {
-      "id": 7,
-      "prompt": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
-      "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
-      "files": [],
-      "expectations": [
-        "Uses Skeleton for the initial load with no prior content",
-        "Uses Spinner for subsequent loads where content is already visible",
-        "Does not use Spinner for the first-paint case"
-      ]
-    },
-    {
-      "id": 8,
-      "prompt": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
-      "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
-      "files": [],
-      "expectations": [
-        "Applies a debounce (~300-400ms) before invoking the search/filter function",
-        "Does not call the search function synchronously on every onChange event"
-      ]
-    }
-  ]
-}
+[
+  {
+    "id": 1,
+    "skills": ["ghds"],
+    "query": "Add a confirmation dialog on the Web Components version of our app that shows a title 'Delete item?' when the user clicks delete.",
+    "expected_output": "Uses <gh-modal heading=\"Delete item?\"> — not `title`, since Web Components' Modal uses the `heading` attribute while `title` is the React/React Native prop name for the identical concept.",
+    "files": [],
+    "expected_behavior": [
+      "Uses the `heading` attribute on <gh-modal>, not `title`",
+      "Does not rely on the native HTML `title` attribute for the dialog's accessible name"
+    ]
+  },
+  {
+    "id": 2,
+    "skills": ["ghds"],
+    "query": "Add a Checkbox to our React Native screen that toggles a 'subscribe' boolean in state.",
+    "expected_output": "Uses <Checkbox onCheckedChange={(checked) => setSubscribe(checked)} /> — React Native's Checkbox uses onCheckedChange with a bare boolean, not onChange with an event object.",
+    "files": [],
+    "expected_behavior": [
+      "Uses `onCheckedChange`, not `onChange`",
+      "The callback receives a bare boolean, not an event object"
+    ]
+  },
+  {
+    "id": 3,
+    "skills": ["ghds"],
+    "query": "Style a custom banner component to match our GHDS primary brand background and text color.",
+    "expected_output": "Uses var(--sys-color-bg-primary) / var(--sys-color-text-onPrimary) (or the equivalent tokens.sys.* JS access on React Native) rather than a hardcoded hex value, preserving the WCAG contrast guarantee.",
+    "files": [],
+    "expected_behavior": [
+      "No hardcoded hex/rgb color values",
+      "References sys.* or comp.* tokens, not ref.* tokens"
+    ]
+  },
+  {
+    "id": 4,
+    "skills": ["ghds"],
+    "query": "After a user saves a settings form successfully, show a brief confirmation and let them keep working on the page.",
+    "expected_output": "Uses Toast (auto-dismissing, non-blocking) rather than Modal or a persistent Alert, since this is a user-initiated action where the result doesn't need to stay pinned to the screen.",
+    "files": [],
+    "expected_behavior": [
+      "Recommends or implements Toast, not Modal",
+      "Does not block user interaction or require an explicit dismiss action"
+    ]
+  },
+  {
+    "id": 5,
+    "skills": ["ghds"],
+    "query": "Add an email input with a label, helper text explaining the required format, and an inline error shown when validation fails.",
+    "expected_output": "Wraps a single Input in FormField with label/helperText/error props, rather than hand-rolling a label and manually wiring aria-describedby/aria-invalid.",
+    "files": [],
+    "expected_behavior": [
+      "Uses FormField wrapping exactly one Input",
+      "Does not manually set aria-describedby/aria-invalid alongside FormField — FormField owns that wiring"
+    ]
+  },
+  {
+    "id": 6,
+    "skills": ["ghds"],
+    "query": "Add a neutral/tertiary 'Cancel' button on our React Native screen, matching the neutral button style used on our React web app.",
+    "expected_output": "Recognizes that React Native's Button variant union only supports 'primary' | 'danger' (no 'neutral') and does not pass variant=\"neutral\" to the React Native Button — uses 'primary' with a note about the platform gap, or an alternative approach.",
+    "files": [],
+    "expected_behavior": [
+      "Does not set variant=\"neutral\" on the React Native Button",
+      "Surfaces or works around the missing 'neutral' variant on React Native rather than silently misusing the prop"
+    ]
+  },
+  {
+    "id": 7,
+    "skills": ["ghds"],
+    "query": "Build a product list screen that shows a loading state before any data has ever been fetched, plus a lighter loading indicator on subsequent refetches.",
+    "expected_output": "Uses Skeleton for the first-paint loading state (no existing content on screen) and Spinner for subsequent refetches (existing content remains visible), per the Skeleton-vs-Spinner decision rule.",
+    "files": [],
+    "expected_behavior": [
+      "Uses Skeleton for the initial load with no prior content",
+      "Uses Spinner for subsequent loads where content is already visible",
+      "Does not use Spinner for the first-paint case"
+    ]
+  },
+  {
+    "id": 8,
+    "skills": ["ghds"],
+    "query": "Add a search input that filters a list as the user types, without hammering the backend on every keystroke.",
+    "expected_output": "Debounces the search callback roughly 300-400ms rather than calling the search function directly inside onChange.",
+    "files": [],
+    "expected_behavior": [
+      "Applies a debounce (~300-400ms) before invoking the search/filter function",
+      "Does not call the search function synchronously on every onChange event"
+    ]
+  }
+]

--- a/.agents/skills/ghds/rules/composition.md
+++ b/.agents/skills/ghds/rules/composition.md
@@ -2,6 +2,14 @@
 
 GHDS components are deliberately small — most real UI is a *pattern*, a recipe combining several components. These are the recurring recipes and the decisions behind them.
 
+## Contents
+
+- FormField wraps exactly one control
+- Validate on blur + submit, not on every keystroke
+- Choosing between Toast, Alert, and Modal
+- Choosing between Skeleton and Spinner
+- Debounce search inputs
+
 ## FormField wraps exactly one control
 
 `FormField` composes a label, helper text, and error message around a **single** form control, wiring `id`/`aria-describedby`/`aria-invalid` to that one control. Wrapping more than one control breaks that wiring — only one of them ends up connected.

--- a/.agents/skills/ghds/rules/platform-differences.md
+++ b/.agents/skills/ghds/rules/platform-differences.md
@@ -2,6 +2,20 @@
 
 GHDS ships the same design as three separate implementations — `@ghds/react`, `@ghds/web-components` (Lit, `gh-*` custom elements), and `@ghds/react-native`. They are **not** a single API with three renderers; prop names, event shapes, and even the supported variant set diverge in specific, verified ways. Do not port a prop name from one platform to another without checking this file first.
 
+## Contents
+
+- Dialog family accessible title: `title` vs `heading`
+- Change events: three different shapes
+- Button content: children vs `label`-only
+- Button `variant`: React Native has no `'neutral'`
+- React-Native-only props
+- Web-Components-only: native form participation
+- Selection groups: Web Components has no shared `value`
+- `orientation` union: React Native uses `'row' | 'column'`
+- `Separator` `decorative` default differs
+- React Native touch adaptations: no hover / no right-click
+- Accessibility prop gaps on React Native
+
 ## Dialog family accessible title: `title` vs `heading`
 
 React and React Native use `title` for a dialog's accessible heading. Web Components uses `heading` for the identical concept. This applies to the **entire dialog family**, not just `Modal`: `Modal`, `AlertDialog`, `Drawer`, and `Sheet` all take `title` on React/React Native and `heading` on Web Components. (`Empty` — an empty-state placeholder, not a dialog — follows the same `title`→`heading` rename in Web Components.)
@@ -89,23 +103,6 @@ React and Web Components support `'primary' | 'danger' | 'neutral'`. React Nativ
 <Button label="Cancel" variant="primary" />
 ```
 
-## Button as a link: Web Components `href` vs React `asChild`
-
-A navigation action that should *look* like a button but behave as a real link (right-clickable, focusable, `Cmd`-clickable) is expressed differently per platform.
-
-```tsx
-// Web Components — set href on gh-button; it renders an <a> internally.
-// target/rel are forwarded. A disabled gh-button stays a <button>.
-<gh-button variant="neutral" href="/ko/" aria-label="한국어로 보기">한국어</gh-button>
-```
-
-```tsx
-// React — Button has no href; use `asChild` to project your own anchor.
-<Button variant="neutral" asChild><a href="/ko/">한국어</a></Button>
-```
-
-React Native has neither — navigation there is a `Button`/`Pressable` with an `onPress` handler that drives your navigator, not an href.
-
 ## React-Native-only props
 
 `testID` and `accessibilityHint` exist only on React Native — they have no equivalent prop on React or Web Components. When porting a component's usage from React/Web Components to React Native, add them where useful for testing/accessibility; when porting the other direction, drop them (they don't exist elsewhere and TypeScript will reject them on React/Web Components).
@@ -113,15 +110,6 @@ React Native has neither — navigation there is a `Button`/`Pressable` with an 
 ## Web-Components-only: native form participation
 
 `Button`, `Checkbox`, and `Switch` on Web Components participate in native `<form>` submission and reset via `ElementInternals`/form-association — a real `<form>` submit or reset affects them automatically. React has no equivalent (plain DOM form semantics apply instead — you wire submission yourself), and React Native has no native `<form>` concept at all.
-
-## Web-Components-only: `gh-navigation-menu` `current`
-
-`gh-navigation-menu` on Web Components takes a `current` property (the active page's path) and highlights the matching item itself: a standalone link matches its path exactly, a dropdown group lights up when a child is the current page or an ancestor of it, and the exact leaf link gets `aria-current="page"`. React and React Native `NavigationMenu` have no `current` prop — mark the active route yourself (React is href-based, so compare against the router location; React Native is selection-callback based, so track the active `value`).
-
-```tsx
-// Web Components — the element resolves the highlight from the path.
-<gh-navigation-menu .items=${items} current="/en/components/button"></gh-navigation-menu>
-```
 
 ## Selection groups: Web Components has no shared `value`
 

--- a/.agents/skills/ghds/rules/theming.md
+++ b/.agents/skills/ghds/rules/theming.md
@@ -1,0 +1,60 @@
+# Theming & Customization
+
+When a consumer wants GHDS to match their brand ("make the primary color blue", "use our brand palette", "match our dark theme"), the answer is **almost never to edit components or hardcode colors** — it is to override GHDS's CSS custom properties. `@ghds/tokens/css` emits a live `comp → sys → ref` reference chain, so redefining one variable cascades to everything that consumes it.
+
+## Rebrand by overriding `--sys-*`, not by hardcoding
+
+The semantic (`--sys-*`) layer is the correct customization surface. Each variable is a role (`primary`, `danger`, `text-link`…), and overriding it re-themes every component that plays that role. Never fork a component or inline a brand color to achieve a theme change.
+
+```css
+/* Incorrect — hardcodes a brand color onto one component; every other
+   primary-colored component (badges, links, focus rings) stays the old color,
+   and dark mode is lost. */
+.my-app .gh-button {
+  background-color: #0969da;
+}
+```
+
+```css
+/* Correct — override the semantic token once; buttons, badges, links, and
+   focus rings that map to the primary role all update together. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+  --sys-color-bg-primary-hover: #0757ba;
+  --sys-color-text-link: #0969da;
+  --sys-color-border-focus: #218bff;
+}
+```
+
+## Always cover dark mode at the same specificity
+
+GHDS toggles themes with a `data-theme="dark"` attribute (falling back to `prefers-color-scheme`). The dark theme re-declares the semantic variables, so a `:root` override alone is silently replaced in dark mode. Set dark values under the dark selector too.
+
+```css
+/* Incorrect — only light is themed; dark mode reverts to GHDS defaults. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+}
+```
+
+```css
+/* Correct — both themes are covered. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+}
+[data-theme="dark"] {
+  --sys-color-bg-primary-default: #218bff;
+}
+```
+
+## Pick the layer that matches the scope of the change
+
+- **`--sys-*` (semantic) — the default.** Change a role: `--sys-color-bg-primary-default`, `--sys-color-text-link`, `--sys-color-border-focus`. Reaches every component using that role.
+- **`--ref-*` (palette) — a whole-palette reskin.** Redefine `--ref-palette-brand-600` to shift every semantic token that references it in one move. Use for changing the underlying color ramp, not a single role.
+- **`--comp-*` (component) — one component only.** Override `--comp-button-bg-primary-default` to retune a single component without touching anything else that shares its semantic token.
+
+Do **not** point a consumer at `--comp-*` for a brand-wide change, or at `--sys-*` when they only want to tweak one component — match the layer to the blast radius.
+
+## React Native has no CSS cascade
+
+CSS-variable overrides apply to `@ghds/react` and `@ghds/web-components` only. React Native resolves tokens as a JS object (`import { tokens } from '@ghds/tokens'`), so there is no runtime `var()` cascade to override — a React Native theme change means supplying different token values in JS, not editing CSS custom properties.

--- a/.changeset/theming-css-variable-references.md
+++ b/.changeset/theming-css-variable-references.md
@@ -1,0 +1,12 @@
+---
+"@ghds/tokens": minor
+---
+
+Preserve token alias chains in the generated CSS. `dist/css/variables.css` now
+emits `comp → sys → ref` aliases as live `var(--…)` references instead of
+resolving every token to a literal. Computed values are unchanged, but the
+cascade is now wired end-to-end: overriding a single `--sys-*` (or `--ref-*`)
+custom property re-themes every component token that aliases it, without
+touching component code. This is what makes app-level theme customization
+(e.g. rebranding the primary color) possible. The TypeScript and React Native
+outputs are unaffected — they remain resolved literal objects.

--- a/apps/website/src/components/ThemePlayground.tsx
+++ b/apps/website/src/components/ThemePlayground.tsx
@@ -1,0 +1,289 @@
+import { Alert } from '@ghds/react/alert';
+import { Badge } from '@ghds/react/badge';
+import { Button } from '@ghds/react/button';
+import { Card } from '@ghds/react/card';
+import { Input } from '@ghds/react/input';
+import { darkTokens, tokens } from '@ghds/tokens';
+// Raw text of the generated token stylesheet — the reference-preserving CSS the
+// package ships. We parse its `:root` (light) and `[data-theme="dark"]` blocks
+// out of it (see THEME_BASE) to pin the preview to a chosen theme.
+import tokensCss from '@ghds/tokens/css?raw';
+import { useMemo, useState } from 'react';
+
+/**
+ * Interactive theming playground.
+ *
+ * GHDS ships its CSS custom properties as a live `comp → sys → ref` reference
+ * chain (see `@ghds/tokens`), so overriding a single semantic `--sys-color-*`
+ * variable re-themes every component that aliases it — no component code
+ * changes. This island demonstrates exactly that: each color picker rewrites
+ * one `--sys-color-*` property on the scoped preview container, and the GHDS
+ * React components inside re-paint instantly.
+ *
+ * Overrides are tracked per theme (light / dark), matching how a real consumer
+ * themes GHDS: `:root { … }` for light and `[data-theme="dark"] { … }` for
+ * dark. The generated snippet emits exactly those blocks, ready to paste.
+ *
+ * Every default value is read from `@ghds/tokens` (never hand-copied), so the
+ * playground follows the source of truth automatically.
+ */
+
+type Theme = 'light' | 'dark';
+
+interface Knob {
+  /** The generated CSS custom property this control overrides. */
+  readonly cssVar: string;
+  /** Human label shown next to the swatch. */
+  readonly label: string;
+  /** Per-theme defaults, sourced from `@ghds/tokens`. */
+  readonly light: string;
+  readonly dark: string;
+}
+
+const cl = tokens.sys.color;
+const cd = darkTokens.sys.color;
+
+/** The curated set of semantic color knobs — the smallest surface that lets a
+ * consumer rebrand GHDS, mirroring shadcn's flat semantic layer. */
+const KNOBS: readonly Knob[] = [
+  {
+    cssVar: '--sys-color-bg-primary-default',
+    label: 'Primary',
+    light: cl.bg.primary.default,
+    dark: cd.bg.primary.default,
+  },
+  {
+    cssVar: '--sys-color-bg-primary-hover',
+    label: 'Primary (hover)',
+    light: cl.bg.primary.hover,
+    dark: cd.bg.primary.hover,
+  },
+  {
+    cssVar: '--sys-color-bg-danger-default',
+    label: 'Danger',
+    light: cl.bg.danger.default,
+    dark: cd.bg.danger.default,
+  },
+  {
+    cssVar: '--sys-color-bg-success-default',
+    label: 'Success',
+    light: cl.bg.success.default,
+    dark: cd.bg.success.default,
+  },
+  {
+    cssVar: '--sys-color-bg-warning-default',
+    label: 'Warning',
+    light: cl.bg.warning.default,
+    dark: cd.bg.warning.default,
+  },
+  {
+    cssVar: '--sys-color-bg-info-default',
+    label: 'Info',
+    light: cl.bg.info.default,
+    dark: cd.bg.info.default,
+  },
+  { cssVar: '--sys-color-bg-canvas', label: 'Canvas', light: cl.bg.canvas, dark: cd.bg.canvas },
+  { cssVar: '--sys-color-bg-surface', label: 'Surface', light: cl.bg.surface, dark: cd.bg.surface },
+  {
+    cssVar: '--sys-color-text-primary',
+    label: 'Text',
+    light: cl.text.primary,
+    dark: cd.text.primary,
+  },
+  {
+    cssVar: '--sys-color-text-secondary',
+    label: 'Text (muted)',
+    light: cl.text.secondary,
+    dark: cd.text.secondary,
+  },
+  { cssVar: '--sys-color-text-link', label: 'Link', light: cl.text.link, dark: cd.text.link },
+  {
+    cssVar: '--sys-color-border-focus',
+    label: 'Focus ring',
+    light: cl.border.focus,
+    dark: cd.border.focus,
+  },
+];
+
+const defaultFor = (knob: Knob, theme: Theme): string =>
+  theme === 'dark' ? knob.dark : knob.light;
+
+/** Knobs whose value in `ov` differs from the theme default — the set that
+ * actually needs to appear in the generated override snippet. */
+function changedFor(ov: Record<string, string>, theme: Theme): Knob[] {
+  return KNOBS.filter((k) => ov[k.cssVar] && ov[k.cssVar] !== defaultFor(k, theme));
+}
+
+/** Parse a single selector block out of the generated stylesheet into a
+ * `{ '--name': value }` map, keeping values in their authored (reference) form. */
+function parseBlock(css: string, marker: string): Record<string, string> {
+  const start = css.indexOf(marker);
+  const open = css.indexOf('{', start);
+  const close = css.indexOf('}', open);
+  const body = css.slice(open + 1, close);
+  const out: Record<string, string> = {};
+  for (const decl of body.split(';')) {
+    const idx = decl.indexOf(':');
+    if (idx === -1) continue;
+    const name = decl.slice(0, idx).trim();
+    if (name.startsWith('--')) out[name] = decl.slice(idx + 1).trim();
+  }
+  return out;
+}
+
+/**
+ * Every custom property from the light / dark theme blocks of the generated
+ * stylesheet, kept in *reference* form (`--comp-x: var(--sys-y)`), applied to
+ * the preview container for the active theme.
+ *
+ * This re-roots the entire `comp → sys → ref` chain at the container. That's
+ * what makes a scoped override work: CSS substitutes a custom property's
+ * `var(...)` at the element where the property is *declared*. Because `--comp-*`
+ * is declared here (not only on the document `:root`), overriding a `--sys-*`
+ * on the container re-substitutes into `--comp-*` within the preview — so
+ * comp-driven components (Button, Badge, Alert) re-theme too, not just elements
+ * that read `--sys-*` directly. It also pins the preview to the chosen theme
+ * regardless of the surrounding site theme.
+ */
+const THEME_BASE: Record<Theme, Record<string, string>> = {
+  light: parseBlock(tokensCss, ':root {'),
+  dark: parseBlock(tokensCss, '[data-theme="dark"] {'),
+};
+
+/** Empty per-theme override maps. */
+const emptyOverrides = (): Record<Theme, Record<string, string>> => ({ light: {}, dark: {} });
+
+export default function ThemePlayground(): React.JSX.Element {
+  const [theme, setTheme] = useState<Theme>('light');
+  const [overrides, setOverrides] = useState<Record<Theme, Record<string, string>>>(emptyOverrides);
+
+  const setColor = (cssVar: string, value: string) =>
+    setOverrides((prev) => ({ ...prev, [theme]: { ...prev[theme], [cssVar]: value } }));
+
+  /** Clear overrides for the theme currently being edited. */
+  const reset = () => setOverrides((prev) => ({ ...prev, [theme]: {} }));
+
+  const changedActive = changedFor(overrides[theme], theme);
+
+  const snippet = useMemo(() => {
+    const block = (selector: string, t: Theme) => {
+      const changed = changedFor(overrides[t], t);
+      if (changed.length === 0) return '';
+      const lines = changed.map((k) => `  ${k.cssVar}: ${overrides[t][k.cssVar]};`);
+      return `${selector} {\n${lines.join('\n')}\n}`;
+    };
+    const blocks = [block(':root', 'light'), block('[data-theme="dark"]', 'dark')].filter(Boolean);
+    return blocks.length > 0
+      ? blocks.join('\n\n')
+      : '/* Adjust a color above to generate your override snippet. */\n:root {\n}';
+  }, [overrides]);
+
+  const hasAnyChange =
+    changedFor(overrides.light, 'light').length > 0 ||
+    changedFor(overrides.dark, 'dark').length > 0;
+
+  const [copied, setCopied] = useState(false);
+  const copy = async () => {
+    try {
+      await navigator.clipboard.writeText(snippet);
+      setCopied(true);
+      setTimeout(() => setCopied(false), 1500);
+    } catch {
+      setCopied(false);
+    }
+  };
+
+  const previewStyle = { ...THEME_BASE[theme], ...overrides[theme] } as React.CSSProperties;
+
+  return (
+    <div className="playground">
+      <div className="playground-controls">
+        <div className="playground-controls-head">
+          <div className="playground-theme-toggle">
+            <Button
+              variant={theme === 'light' ? 'primary' : 'neutral'}
+              aria-pressed={theme === 'light'}
+              onClick={() => setTheme('light')}
+            >
+              Light
+            </Button>
+            <Button
+              variant={theme === 'dark' ? 'primary' : 'neutral'}
+              aria-pressed={theme === 'dark'}
+              onClick={() => setTheme('dark')}
+            >
+              Dark
+            </Button>
+          </div>
+          <Button variant="neutral" onClick={reset} disabled={changedActive.length === 0}>
+            Reset
+          </Button>
+        </div>
+        <div className="playground-swatches">
+          {KNOBS.map((k) => {
+            const current = overrides[theme][k.cssVar] ?? defaultFor(k, theme);
+            return (
+              <label key={k.cssVar} className="playground-swatch">
+                <input
+                  type="color"
+                  value={current}
+                  aria-label={`${k.label} color (${theme})`}
+                  onChange={(e) => setColor(k.cssVar, e.target.value)}
+                />
+                <span className="playground-swatch-label">
+                  <span className="playground-swatch-name">{k.label}</span>
+                  <code>{current}</code>
+                </span>
+              </label>
+            );
+          })}
+        </div>
+      </div>
+
+      {/* Scoped preview — every `--sys-color-*` is set on this container for the
+          active theme, so the GHDS components below re-theme live without
+          touching the site chrome. */}
+      <div className="playground-preview" data-theme={theme} style={previewStyle}>
+        <div className="demo-row">
+          <Button variant="primary">Primary</Button>
+          <Button variant="danger">Delete</Button>
+          <Button variant="neutral">Cancel</Button>
+        </div>
+        <div className="demo-row">
+          <Badge variant="primary">Primary</Badge>
+          <Badge variant="success">Success</Badge>
+          <Badge variant="warning">Warning</Badge>
+          <Badge variant="info">Info</Badge>
+          <Badge variant="danger">Danger</Badge>
+        </div>
+        <Card fill="solid">
+          <Input label="Email" placeholder="you@example.com" />
+          <p style={{ margin: 0, color: 'var(--sys-color-text-secondary)' }}>
+            Body text in a card, with an{' '}
+            <a href="#playground" style={{ color: 'var(--sys-color-text-link)' }}>
+              inline link
+            </a>
+            .
+          </p>
+        </Card>
+        <Alert variant="info" title="Heads up">
+          This alert re-themes from the same tokens.
+        </Alert>
+      </div>
+
+      <div className="playground-output">
+        <div className="playground-output-head">
+          <span className="demo-label" style={{ margin: 0 }}>
+            Your override — paste into your global stylesheet
+          </span>
+          <Button variant="neutral" onClick={copy} disabled={!hasAnyChange}>
+            {copied ? 'Copied!' : 'Copy CSS'}
+          </Button>
+        </div>
+        <pre>
+          <code>{snippet}</code>
+        </pre>
+      </div>
+    </div>
+  );
+}

--- a/apps/website/src/lib/nav.ts
+++ b/apps/website/src/lib/nav.ts
@@ -44,6 +44,14 @@ export const NAV: readonly NavItem[] = [
     },
   },
   {
+    href: '/theming/',
+    label: { en: 'Theming', ko: '테마 커스터마이징' },
+    summary: {
+      en: 'Rebrand GHDS by overriding a few CSS variables — with a live playground.',
+      ko: 'CSS 변수 몇 개만 덮어써서 GHDS를 리브랜딩하세요 — 실시간 playground 포함.',
+    },
+  },
+  {
     href: '/components/',
     label: { en: 'Components', ko: '컴포넌트' },
     summary: {
@@ -137,7 +145,12 @@ export const NAV_CATEGORIES: readonly NavCategory[] = [
   },
   {
     label: { en: 'Foundations', ko: '파운데이션' },
-    children: [byHref('/fonts/'), byHref('/design-style/'), byHref('/foundations/')],
+    children: [
+      byHref('/fonts/'),
+      byHref('/design-style/'),
+      byHref('/foundations/'),
+      byHref('/theming/'),
+    ],
   },
   {
     label: { en: 'Library', ko: '라이브러리' },

--- a/apps/website/src/pages/en/theming.astro
+++ b/apps/website/src/pages/en/theming.astro
@@ -1,0 +1,101 @@
+---
+import ThemePlayground from '../../components/ThemePlayground.tsx';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { withBase } from '../../lib/withBase';
+---
+
+<BaseLayout
+  title="Theming"
+  description="Rebrand GHDS by overriding a handful of CSS custom properties — no component code, no fork."
+>
+  <section class="page-intro">
+    <span class="eyebrow">Guides</span>
+    <h1>Theming</h1>
+    <p>
+      GHDS is built to be re-skinned. Every color a component paints resolves through a live
+      <code>comp → sys → ref</code> chain of CSS custom properties, so overriding one semantic
+      variable re-themes everything that uses it — without touching component code or forking the
+      library.
+    </p>
+  </section>
+
+  <section class="section prose">
+    <h2>How theming works</h2>
+    <p>
+      <code>@ghds/tokens</code> emits its CSS variables as a <strong>reference chain</strong>, not
+      as flat literals. A component reads its own <code>--comp-*</code> variable, which aliases a
+      semantic <code>--sys-*</code> variable, which in turn aliases a raw <code>--ref-*</code> value:
+    </p>
+    <pre><code>{`--ref-palette-brand-600: #3e47c9;                            /* raw value      */
+--sys-color-bg-primary-default: var(--ref-palette-brand-600); /* semantic role */
+--comp-button-bg-primary-default: var(--sys-color-bg-primary-default); /* component */`}</code></pre>
+    <p>
+      Because the aliases stay live at runtime, redefining any link in the chain cascades downward.
+      Override <code>--sys-color-bg-primary-default</code> and every component that maps to the
+      primary role — buttons, badges, links, focus rings — updates at once.
+    </p>
+
+    <h2>Customizing in three steps</h2>
+    <h3>1. Load the token stylesheet</h3>
+    <p>Import it once, at your app's entry point. This defines every default variable:</p>
+    <pre><code>{`import '@ghds/tokens/css';`}</code></pre>
+
+    <h3>2. Override the variables you want</h3>
+    <p>
+      In your own global stylesheet, redefine the semantic variables under <code>:root</code>. You
+      never edit component code — you re-point the tokens they already consume:
+    </p>
+    <pre><code>{`:root {
+  --sys-color-bg-primary-default: #0969da;
+  --sys-color-bg-primary-hover:   #0757ba;
+  --sys-color-text-link:          #0969da;
+  --sys-color-border-focus:       #218bff;
+}`}</code></pre>
+
+    <h3>3. Cover dark mode</h3>
+    <p>
+      GHDS switches themes with a <code>data-theme="dark"</code> attribute (falling back to
+      <code>prefers-color-scheme</code>). The dark theme re-declares the semantic variables, so set
+      your dark values at the same specificity or they'll be overridden:
+    </p>
+    <pre><code>{`[data-theme="dark"] {
+  --sys-color-bg-primary-default: #218bff;
+  --sys-color-text-link:          #6cb6ff;
+}`}</code></pre>
+
+    <h2>Which layer should I override?</h2>
+    <ul>
+      <li>
+        <strong><code>--sys-*</code> (semantic) — start here.</strong> The safest, highest-leverage
+        surface. Each variable is a role (<code>primary</code>, <code>danger</code>,
+        <code>text-link</code>…), so an override reads clearly and reaches every component that plays
+        that role. The playground below edits this layer.
+      </li>
+      <li>
+        <strong><code>--ref-*</code> (palette) — for a whole-palette reskin.</strong> Redefining
+        <code>--ref-palette-brand-600</code> shifts every semantic token that references it, in one
+        move. Use when you're changing the underlying color ramp, not a single role.
+      </li>
+      <li>
+        <strong><code>--comp-*</code> (component) — for one component only.</strong> Override
+        <code>--comp-button-bg-primary-default</code> to retune a single component without affecting
+        anything else that shares its semantic token.
+      </li>
+    </ul>
+    <p>
+      The full list of semantic variables and their default light/dark values lives on the
+      <a href={withBase('/design-style/')}>Design Style</a> page.
+    </p>
+  </section>
+
+  <section class="section" id="playground">
+    <h2>Playground</h2>
+    <p class="demo-label">
+      Adjust the semantic colors and watch real GHDS components re-theme. Switch between Light and
+      Dark to set each theme's values independently — the generated CSS emits a <code>:root</code>
+      block and a <code>[data-theme="dark"]</code> block, ready to paste into your stylesheet.
+    </p>
+    {/* client:only — GHDS React components paint their sketch surface in the browser. */}
+    <ThemePlayground client:only="react" />
+  </section>
+</BaseLayout>

--- a/apps/website/src/pages/ko/theming.astro
+++ b/apps/website/src/pages/ko/theming.astro
@@ -1,0 +1,101 @@
+---
+import ThemePlayground from '../../components/ThemePlayground.tsx';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+import { withBase } from '../../lib/withBase';
+---
+
+<BaseLayout
+  title="테마 커스터마이징"
+  description="CSS 커스텀 속성 몇 개만 덮어써서 GHDS를 리브랜딩하세요 — 컴포넌트 코드 수정도, 포크도 필요 없습니다."
+>
+  <section class="page-intro">
+    <span class="eyebrow">가이드</span>
+    <h1>테마 커스터마이징</h1>
+    <p>
+      GHDS는 다시 입히기 쉽게 설계되었습니다. 컴포넌트가 칠하는 모든 색은 살아있는
+      <code>comp → sys → ref</code> CSS 커스텀 속성 체인을 통해 해석되므로, 시맨틱 변수 하나만
+      덮어써도 그 변수를 쓰는 모든 것이 재테마링됩니다 — 컴포넌트 코드를 건드리거나 라이브러리를
+      포크할 필요가 없습니다.
+    </p>
+  </section>
+
+  <section class="section prose">
+    <h2>테마링 동작 원리</h2>
+    <p>
+      <code>@ghds/tokens</code>는 CSS 변수를 평탄한 리터럴이 아니라 <strong>참조 체인</strong>으로
+      내보냅니다. 컴포넌트는 자신의 <code>--comp-*</code> 변수를 읽고, 이는 시맨틱
+      <code>--sys-*</code> 변수를 가리키며, 그것은 다시 원시 <code>--ref-*</code> 값을 가리킵니다:
+    </p>
+    <pre><code>{`--ref-palette-brand-600: #3e47c9;                            /* 원시 값     */
+--sys-color-bg-primary-default: var(--ref-palette-brand-600); /* 시맨틱 역할 */
+--comp-button-bg-primary-default: var(--sys-color-bg-primary-default); /* 컴포넌트 */`}</code></pre>
+    <p>
+      별칭이 런타임에 살아있기 때문에, 체인의 어느 고리든 재정의하면 아래로 cascade됩니다.
+      <code>--sys-color-bg-primary-default</code>를 덮어쓰면 primary 역할에 매핑된 모든
+      컴포넌트 — 버튼, 배지, 링크, 포커스 링 — 이 한 번에 바뀝니다.
+    </p>
+
+    <h2>세 단계로 커스터마이징하기</h2>
+    <h3>1. 토큰 스타일시트 로드</h3>
+    <p>앱 진입점에서 한 번만 임포트하세요. 모든 기본 변수가 정의됩니다:</p>
+    <pre><code>{`import '@ghds/tokens/css';`}</code></pre>
+
+    <h3>2. 원하는 변수 덮어쓰기</h3>
+    <p>
+      여러분의 전역 스타일시트에서 <code>:root</code> 아래에 시맨틱 변수를 재정의하세요. 컴포넌트
+      코드는 절대 수정하지 않습니다 — 컴포넌트가 이미 소비하는 토큰을 다시 가리키게 할 뿐입니다:
+    </p>
+    <pre><code>{`:root {
+  --sys-color-bg-primary-default: #0969da;
+  --sys-color-bg-primary-hover:   #0757ba;
+  --sys-color-text-link:          #0969da;
+  --sys-color-border-focus:       #218bff;
+}`}</code></pre>
+
+    <h3>3. 다크 모드 대응</h3>
+    <p>
+      GHDS는 <code>data-theme="dark"</code> 속성으로 테마를 전환합니다(없으면
+      <code>prefers-color-scheme</code>로 폴백). 다크 테마는 시맨틱 변수를 다시 선언하므로,
+      같은 명시도(specificity)에서 다크 값을 지정하지 않으면 덮어써집니다:
+    </p>
+    <pre><code>{`[data-theme="dark"] {
+  --sys-color-bg-primary-default: #218bff;
+  --sys-color-text-link:          #6cb6ff;
+}`}</code></pre>
+
+    <h2>어느 계층을 덮어써야 할까?</h2>
+    <ul>
+      <li>
+        <strong><code>--sys-*</code> (시맨틱) — 여기서 시작하세요.</strong> 가장 안전하고 효율이
+        높은 표면입니다. 각 변수가 역할(<code>primary</code>, <code>danger</code>,
+        <code>text-link</code>…)이라 오버라이드의 의도가 명확하고, 그 역할을 하는 모든 컴포넌트에
+        도달합니다. 아래 playground가 이 계층을 편집합니다.
+      </li>
+      <li>
+        <strong><code>--ref-*</code> (팔레트) — 팔레트 전체를 갈아엎을 때.</strong>
+        <code>--ref-palette-brand-600</code>을 재정의하면 이를 참조하는 모든 시맨틱 토큰이 한
+        번에 이동합니다. 단일 역할이 아니라 밑바탕 컬러 램프를 바꿀 때 사용하세요.
+      </li>
+      <li>
+        <strong><code>--comp-*</code> (컴포넌트) — 특정 컴포넌트 하나만.</strong>
+        <code>--comp-button-bg-primary-default</code>를 덮어쓰면 같은 시맨틱 토큰을 공유하는 다른
+        것에 영향을 주지 않고 그 컴포넌트만 미세 조정합니다.
+      </li>
+    </ul>
+    <p>
+      시맨틱 변수 전체 목록과 라이트/다크 기본값은
+      <a href={withBase('/design-style/')}>디자인 스타일</a> 페이지에 있습니다.
+    </p>
+  </section>
+
+  <section class="section" id="playground">
+    <h2>Playground</h2>
+    <p class="demo-label">
+      시맨틱 색상을 조절하면 실제 GHDS 컴포넌트가 실시간으로 재테마링됩니다. Light/Dark를 전환해
+      테마별 값을 따로 지정하세요 — 생성된 CSS는 <code>:root</code> 블록과
+      <code>[data-theme="dark"]</code> 블록을 함께 내보내므로 그대로 스타일시트에 붙여넣으면 됩니다.
+    </p>
+    {/* client:only — GHDS React 컴포넌트는 브라우저에서 스케치 표면을 그립니다. */}
+    <ThemePlayground client:only="react" />
+  </section>
+</BaseLayout>

--- a/apps/website/src/styles/global.css
+++ b/apps/website/src/styles/global.css
@@ -393,6 +393,101 @@ code {
   gap: var(--sys-spacing-lg);
 }
 
+/* ---- Theme playground ---------------------------------------------- */
+
+.playground {
+  display: grid;
+  grid-template-columns: minmax(16rem, 22rem) 1fr;
+  gap: var(--sys-spacing-lg);
+  align-items: start;
+}
+
+@media (max-width: 48rem) {
+  .playground {
+    grid-template-columns: 1fr;
+  }
+}
+
+.playground-controls,
+.playground-output {
+  min-width: 0;
+}
+
+.playground-controls-head,
+.playground-output-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: var(--sys-spacing-sm);
+  margin-bottom: var(--sys-spacing-sm);
+  flex-wrap: wrap;
+}
+
+.playground-theme-toggle {
+  display: inline-flex;
+  gap: var(--sys-spacing-xs);
+}
+
+.playground-swatches {
+  display: grid;
+  gap: var(--sys-spacing-xs);
+}
+
+.playground-swatch {
+  display: flex;
+  align-items: center;
+  gap: var(--sys-spacing-sm);
+  cursor: pointer;
+}
+
+.playground-swatch input[type="color"] {
+  inline-size: var(--sys-spacing-xl);
+  block-size: var(--sys-spacing-xl);
+  padding: 0;
+  border: var(--sys-border-width-thin) solid var(--sys-color-border-default);
+  border-radius: var(--sys-radius-sm);
+  background: none;
+  cursor: pointer;
+}
+
+.playground-swatch-label {
+  display: flex;
+  flex-direction: column;
+  line-height: 1.2;
+}
+
+.playground-swatch-name {
+  font-family: var(--sys-typography-label-fontFamily);
+  font-size: var(--sys-typography-label-fontSize);
+  color: var(--sys-color-text-primary);
+}
+
+.playground-swatch-label code {
+  background: none;
+  padding: 0;
+  font-size: var(--sys-typography-caption-fontSize);
+  color: var(--sys-color-text-secondary);
+}
+
+/* The live preview is a self-contained light canvas: every `--sys-color-*` is
+ * set inline on this element, so nested components resolve their `--comp-*`
+ * aliases here rather than inheriting the surrounding site theme. */
+.playground-preview {
+  display: flex;
+  flex-direction: column;
+  gap: var(--sys-spacing-md);
+  padding: var(--sys-spacing-lg);
+  background-color: var(--sys-color-bg-canvas);
+  border: var(--sys-border-width-default) solid var(--sys-color-border-default);
+  border-radius: var(--sys-radius-lg);
+  color: var(--sys-color-text-primary);
+  grid-row: span 2;
+}
+
+.playground-output pre {
+  margin: 0;
+}
+
 /* ---- Prose (MDX content pages) -------------------------------------- */
 
 .prose {

--- a/packages/tokens/style-dictionary.config.js
+++ b/packages/tokens/style-dictionary.config.js
@@ -128,12 +128,30 @@ StyleDictionary.registerTransform({
   },
 });
 
+/**
+ * A token's CSS value with `{a.b.c}` aliases preserved as `var(--a-b-c)`
+ * references instead of resolved to a literal. Keeping the alias live means the
+ * whole `comp → sys → ref` chain stays wired at runtime: a consumer can
+ * override a single `--sys-*` (or `--ref-*`) custom property and every token
+ * that aliases it re-themes, without touching component code. Literal values
+ * (the `ref` tier, and any non-string leaf like `lineHeight`) pass through
+ * unchanged. Composite strings (e.g. a shadow referencing a color) have each
+ * `{…}` segment swapped independently, so partial references work too.
+ */
+function cssValue(token) {
+  const original = token.original?.$value;
+  if (typeof original === 'string' && original.includes('{')) {
+    return original.replace(/\{([^}]+)\}/g, (_, ref) => `var(--${ref.split('.').join('-')})`);
+  }
+  return token.$value;
+}
+
 StyleDictionary.registerFormat({
   name: 'ghds/css',
   format: ({ dictionary, options }) => {
     const selector = options.selector ?? ':root';
     const lines = dictionary.allTokens.map(
-      (token) => `  --${token.path.join('-')}: ${token.$value};`,
+      (token) => `  --${token.path.join('-')}: ${cssValue(token)};`,
     );
     return `${HEADER}${selector} {\n${lines.join('\n')}\n}\n`;
   },

--- a/skills/ghds/SKILL.md
+++ b/skills/ghds/SKILL.md
@@ -42,6 +42,7 @@ import { tokens } from '@ghds/tokens';
 Each rule below is enforced — follow the link for the full Incorrect/Correct code pairs.
 
 - **[Token usage](rules/tokens.md)** — always consume `sys.*`/`comp.*` tokens, never `ref.*` directly or a hardcoded value.
+- **[Theming](rules/theming.md)** — rebrand by overriding `--sys-*` CSS custom properties (they cascade to every component), never by hardcoding brand colors or forking components; always cover dark mode.
 - **[Accessibility](rules/accessibility.md)** — ARIA patterns, keyboard interaction, and focus management per component.
 - **[Composition](rules/composition.md)** — `FormField` wraps exactly one control; choosing between Toast/Alert/Modal and Skeleton/Spinner; debounce search inputs.
 - **[Platform differences](rules/platform-differences.md)** — prop and event naming diverges across React / Web Components / React Native. Never port a prop name from one platform to another without checking this file.
@@ -180,6 +181,7 @@ All components below exist on all three platforms (`@ghds/react`, `@ghds/web-com
 ## Reference
 
 - [rules/tokens.md](rules/tokens.md) — token consumption rules
+- [rules/theming.md](rules/theming.md) — rebranding/customization via CSS-variable overrides
 - [rules/accessibility.md](rules/accessibility.md) — ARIA, keyboard, focus management
 - [rules/composition.md](rules/composition.md) — component composition patterns
 - [rules/platform-differences.md](rules/platform-differences.md) — React / Web Components / React Native API differences

--- a/skills/ghds/rules/theming.md
+++ b/skills/ghds/rules/theming.md
@@ -1,0 +1,60 @@
+# Theming & Customization
+
+When a consumer wants GHDS to match their brand ("make the primary color blue", "use our brand palette", "match our dark theme"), the answer is **almost never to edit components or hardcode colors** — it is to override GHDS's CSS custom properties. `@ghds/tokens/css` emits a live `comp → sys → ref` reference chain, so redefining one variable cascades to everything that consumes it.
+
+## Rebrand by overriding `--sys-*`, not by hardcoding
+
+The semantic (`--sys-*`) layer is the correct customization surface. Each variable is a role (`primary`, `danger`, `text-link`…), and overriding it re-themes every component that plays that role. Never fork a component or inline a brand color to achieve a theme change.
+
+```css
+/* Incorrect — hardcodes a brand color onto one component; every other
+   primary-colored component (badges, links, focus rings) stays the old color,
+   and dark mode is lost. */
+.my-app .gh-button {
+  background-color: #0969da;
+}
+```
+
+```css
+/* Correct — override the semantic token once; buttons, badges, links, and
+   focus rings that map to the primary role all update together. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+  --sys-color-bg-primary-hover: #0757ba;
+  --sys-color-text-link: #0969da;
+  --sys-color-border-focus: #218bff;
+}
+```
+
+## Always cover dark mode at the same specificity
+
+GHDS toggles themes with a `data-theme="dark"` attribute (falling back to `prefers-color-scheme`). The dark theme re-declares the semantic variables, so a `:root` override alone is silently replaced in dark mode. Set dark values under the dark selector too.
+
+```css
+/* Incorrect — only light is themed; dark mode reverts to GHDS defaults. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+}
+```
+
+```css
+/* Correct — both themes are covered. */
+:root {
+  --sys-color-bg-primary-default: #0969da;
+}
+[data-theme="dark"] {
+  --sys-color-bg-primary-default: #218bff;
+}
+```
+
+## Pick the layer that matches the scope of the change
+
+- **`--sys-*` (semantic) — the default.** Change a role: `--sys-color-bg-primary-default`, `--sys-color-text-link`, `--sys-color-border-focus`. Reaches every component using that role.
+- **`--ref-*` (palette) — a whole-palette reskin.** Redefine `--ref-palette-brand-600` to shift every semantic token that references it in one move. Use for changing the underlying color ramp, not a single role.
+- **`--comp-*` (component) — one component only.** Override `--comp-button-bg-primary-default` to retune a single component without touching anything else that shares its semantic token.
+
+Do **not** point a consumer at `--comp-*` for a brand-wide change, or at `--sys-*` when they only want to tweak one component — match the layer to the blast radius.
+
+## React Native has no CSS cascade
+
+CSS-variable overrides apply to `@ghds/react` and `@ghds/web-components` only. React Native resolves tokens as a JS object (`import { tokens } from '@ghds/tokens'`), so there is no runtime `var()` cascade to override — a React Native theme change means supplying different token values in JS, not editing CSS custom properties.


### PR DESCRIPTION
## Summary

Makes GHDS **rebrandable at the app level** — a consumer overrides a few CSS custom properties and every component re-themes, with no component-code changes or fork. Adds docs + an interactive playground on the site, and a Skill rule so AI agents do the same.

This started from a question about how shadcn lets users customize colors, and surfaced that GHDS's shipped CSS **resolved every token to a literal**, so `--sys-*` overrides did nothing for the 55/56 React components that read `--comp-*`. This PR fixes that first, then builds on it.

## Changes

### `@ghds/tokens` (the enabling fix)
- The `ghds/css` format now preserves `comp → sys → ref` aliases as live `var(--…)` references instead of flattening to literals. Overriding one `--sys-*` (or `--ref-*`) now cascades through `--comp-*` to the component. Computed values are unchanged; TS/RN/JSON outputs stay resolved literals (RN has no CSS cascade). Changeset included (minor).

### Website
- **Theming guide** (`/theming/`, en + ko): how the reference chain works, the three-step override flow (load stylesheet → override `--sys-*` → cover dark mode), and which tier to override (`sys` / `ref` / `comp`).
- **ThemePlayground island**: 12 curated semantic-color knobs, a **Light/Dark toggle** with per-theme editing, a scoped live preview of real GHDS components, and a copyable `:root` + `[data-theme="dark"]` snippet. Defaults come from `@ghds/tokens` (never hand-copied). The preview re-declares the full theme var set on its container so comp-driven components re-theme within the scoped preview.
- Wired into the Foundations nav.

### Skill (`ghds`)
- New `rules/theming.md` (both skill copies) + references in `SKILL.md`, so agents rebrand via `--sys-*` overrides + dark-mode coverage instead of hardcoding brand colors.

## The CSS gotcha this exposed

A custom property's `var()` is substituted where the property is **declared**. `--comp-*` is declared on `:root`, so its `var(--sys-*)` resolves against `:root`'s value — overriding `--sys-*` on a *nested* element does **not** re-theme comp components (only elements reading `--sys-*` directly). Consumers must override at `:root` (docs/Skill say so). The playground works around it by re-declaring the full theme var set on its preview container.

## Verification
- `pnpm check` (biome) — all 10 packages clean.
- `pnpm test` — 14/14 (react 325, react-native 279, web-components 67, tokens, website, sketch-core, icons).
- Website build: 112 pages.
- **Real-browser (Playwright/Chromium)**: confirmed overriding a `--sys-*` recolors a comp-driven Button through the chain, the link (direct-sys) recolors, the Light/Dark toggle pins the preview + loads per-theme defaults, dark overrides recolor comp components, and the snippet emits the correct per-theme blocks. No console errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)